### PR TITLE
fix: resolve lint and formatting errors blocking prepublishOnly

### DIFF
--- a/src/components/calendar/AgendaList.tsx
+++ b/src/components/calendar/AgendaList.tsx
@@ -1,4 +1,5 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
 import type { AgendaListProps } from '../../types/components.js';
 import type { CalendarEvent } from '../../types/event.js';
 import {
@@ -66,7 +67,9 @@ export function AgendaList({
           // Bloque día: abreviación + número (circle si es hoy)
           React.createElement(
             'div',
-            { className: `flex flex-col items-center w-10 shrink-0 ${isToday ? 'text-cg-accent' : 'text-cg-text-muted'}` },
+            {
+              className: `flex flex-col items-center w-10 shrink-0 ${isToday ? 'text-cg-accent' : 'text-cg-text-muted'}`,
+            },
             React.createElement(
               'span',
               { className: 'text-[9px] font-bold tracking-widest leading-none mb-0.5' },
@@ -95,7 +98,10 @@ export function AgendaList({
             isToday &&
               React.createElement(
                 'span',
-                { className: 'text-[9px] font-bold text-cg-accent uppercase tracking-widest leading-none' },
+                {
+                  className:
+                    'text-[9px] font-bold text-cg-accent uppercase tracking-widest leading-none',
+                },
                 'Hoy'
               )
           ),
@@ -152,7 +158,10 @@ export function AgendaList({
                 evt.location &&
                   React.createElement(
                     'div',
-                    { className: 'flex items-center gap-1 text-xs text-cg-text-muted truncate mt-0.5' },
+                    {
+                      className:
+                        'flex items-center gap-1 text-xs text-cg-text-muted truncate mt-0.5',
+                    },
                     React.createElement(PinIcon, null),
                     evt.location
                   )

--- a/src/components/calendar/CalendarSkeleton.tsx
+++ b/src/components/calendar/CalendarSkeleton.tsx
@@ -4,17 +4,28 @@ const React = getHostReact();
 const UI = getHostUI();
 
 const WEEK_DAYS = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
-const TIME_LABELS = ['08:00', '09:00', '10:00', '11:00', '12:00', '13:00', '14:00', '15:00', '16:00', '17:00'];
+const TIME_LABELS = [
+  '08:00',
+  '09:00',
+  '10:00',
+  '11:00',
+  '12:00',
+  '13:00',
+  '14:00',
+  '15:00',
+  '16:00',
+  '17:00',
+];
 const SLOT_H = 48;
 
 // Eventos ficticios distribuidos en la semana para el skeleton de WeekGrid
 const WEEK_GHOST_EVENTS = [
   { col: 0, top: SLOT_H * 1.5, h: SLOT_H * 1 },
-  { col: 1, top: SLOT_H * 3,   h: SLOT_H * 2 },
+  { col: 1, top: SLOT_H * 3, h: SLOT_H * 2 },
   { col: 2, top: SLOT_H * 0.5, h: SLOT_H * 1.5 },
-  { col: 4, top: SLOT_H * 2,   h: SLOT_H * 1 },
-  { col: 5, top: SLOT_H * 4,   h: SLOT_H * 0.5 },
-  { col: 6, top: SLOT_H * 1,   h: SLOT_H * 2 },
+  { col: 4, top: SLOT_H * 2, h: SLOT_H * 1 },
+  { col: 5, top: SLOT_H * 4, h: SLOT_H * 0.5 },
+  { col: 6, top: SLOT_H * 1, h: SLOT_H * 2 },
 ];
 
 export function MonthGridSkeleton() {
@@ -49,9 +60,7 @@ export function MonthGridSkeleton() {
           i % 7 !== 5 && i % 7 !== 6 && i % 4 !== 0
             ? React.createElement(UI.Skeleton, { className: 'h-4 w-full rounded mb-1' })
             : null,
-          i % 5 === 0
-            ? React.createElement(UI.Skeleton, { className: 'h-4 w-3/4 rounded' })
-            : null
+          i % 5 === 0 ? React.createElement(UI.Skeleton, { className: 'h-4 w-3/4 rounded' }) : null
         )
       )
     )
@@ -59,8 +68,6 @@ export function MonthGridSkeleton() {
 }
 
 export function WeekGridSkeleton() {
-  const colCount = WEEK_DAYS.length;
-
   return React.createElement(
     'div',
     { className: 'flex animate-pulse' },
@@ -75,7 +82,8 @@ export function WeekGridSkeleton() {
           'div',
           {
             key: t,
-            className: 'text-[10px] text-cg-text-muted text-right pr-2 border-b border-cg-border/30',
+            className:
+              'text-[10px] text-cg-text-muted text-right pr-2 border-b border-cg-border/30',
             style: { height: `${SLOT_H}px` },
           },
           t
@@ -92,7 +100,10 @@ export function WeekGridSkeleton() {
         // Header del día
         React.createElement(
           'div',
-          { className: 'h-10 flex flex-col items-center justify-center border-b border-cg-border gap-0.5' },
+          {
+            className:
+              'h-10 flex flex-col items-center justify-center border-b border-cg-border gap-0.5',
+          },
           React.createElement(UI.Skeleton, { className: 'w-6 h-2.5 rounded' }),
           React.createElement(UI.Skeleton, { className: 'w-5 h-4 rounded' })
         ),
@@ -102,7 +113,7 @@ export function WeekGridSkeleton() {
           'div',
           { className: 'relative', style: { height: `${SLOT_H * TIME_LABELS.length}px` } },
           // Líneas de hora
-          TIME_LABELS.map((t, i) =>
+          TIME_LABELS.map((t) =>
             React.createElement('div', {
               key: t,
               className: 'border-b border-cg-border/20',
@@ -126,9 +137,9 @@ export function WeekGridSkeleton() {
 export function DayColumnSkeleton() {
   // Eventos fantasma para la columna única
   const ghostEvents = [
-    { top: SLOT_H * 1,   h: SLOT_H * 1.5 },
+    { top: SLOT_H * 1, h: SLOT_H * 1.5 },
     { top: SLOT_H * 3.5, h: SLOT_H * 1 },
-    { top: SLOT_H * 6,   h: SLOT_H * 2 },
+    { top: SLOT_H * 6, h: SLOT_H * 2 },
   ];
 
   return React.createElement(
@@ -181,11 +192,7 @@ export function DayColumnSkeleton() {
 
 export function AgendaListSkeleton() {
   // 3 grupos de fecha con 2–3 eventos cada uno
-  const groups = [
-    { events: 3 },
-    { events: 2 },
-    { events: 3 },
-  ];
+  const groups = [{ events: 3 }, { events: 2 }, { events: 3 }];
 
   return React.createElement(
     'div',
@@ -230,7 +237,9 @@ export function AgendaListSkeleton() {
               React.createElement(
                 'div',
                 { className: 'flex-1 flex flex-col gap-1.5' },
-                React.createElement(UI.Skeleton, { className: `h-3.5 rounded ${ei % 2 === 0 ? 'w-2/3' : 'w-1/2'}` }),
+                React.createElement(UI.Skeleton, {
+                  className: `h-3.5 rounded ${ei % 2 === 0 ? 'w-2/3' : 'w-1/2'}`,
+                }),
                 ei % 3 === 0
                   ? React.createElement(UI.Skeleton, { className: 'h-2.5 w-1/3 rounded' })
                   : null

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,11 +1,11 @@
 import { getHostReact, getHostUI, useViewContributions } from '@coongro/plugin-sdk';
-import type { CalendarViewProps, CalendarViewMode } from '../../types/components.js';
-import { useEvents } from '../../hooks/useEvents.js';
+
 import { useCalendarSettings } from '../../hooks/useCalendarSettings.js';
 import { useDateNavigation } from '../../hooks/useDateNavigation.js';
-import { MonthGrid } from './MonthGrid.js';
-import { WeekGrid } from './WeekGrid.js';
-import { DayColumn } from './DayColumn.js';
+import { useEvents } from '../../hooks/useEvents.js';
+import type { CalendarViewProps, CalendarViewMode } from '../../types/components.js';
+import { toDateString } from '../../utils/date.js';
+
 import { AgendaList } from './AgendaList.js';
 import {
   MonthGridSkeleton,
@@ -13,8 +13,10 @@ import {
   DayColumnSkeleton,
   AgendaListSkeleton,
 } from './CalendarSkeleton.js';
+import { DayColumn } from './DayColumn.js';
 import { MiniCalendar } from './MiniCalendar.js';
-import { toDateString } from '../../utils/date.js';
+import { MonthGrid } from './MonthGrid.js';
+import { WeekGrid } from './WeekGrid.js';
 
 const React = getHostReact();
 const UI = getHostUI();
@@ -38,7 +40,7 @@ export function CalendarView({
   className = '',
 }: CalendarViewProps) {
   const { settings } = useCalendarSettings();
-  const nav = useDateNavigation((defaultView ?? settings.defaultView) as CalendarViewMode);
+  const nav = useDateNavigation(defaultView ?? settings.defaultView);
 
   const { data: events, loading } = useEvents({
     from: nav.rangeStart,
@@ -116,11 +118,16 @@ export function CalendarView({
   const renderActiveView = () => {
     if (loading) {
       switch (nav.view) {
-        case 'month':   return React.createElement(MonthGridSkeleton, null);
-        case 'week':    return React.createElement(WeekGridSkeleton, null);
-        case 'day':     return React.createElement(DayColumnSkeleton, null);
-        case 'agenda':  return React.createElement(AgendaListSkeleton, null);
-        default:        return React.createElement(MonthGridSkeleton, null);
+        case 'month':
+          return React.createElement(MonthGridSkeleton, null);
+        case 'week':
+          return React.createElement(WeekGridSkeleton, null);
+        case 'day':
+          return React.createElement(DayColumnSkeleton, null);
+        case 'agenda':
+          return React.createElement(AgendaListSkeleton, null);
+        default:
+          return React.createElement(MonthGridSkeleton, null);
       }
     }
 
@@ -148,7 +155,8 @@ export function CalendarView({
           renderEvent,
           onEventClick,
           onSlotClick: onSlotClick
-            ? (date, hour) => onSlotClick(`${date}T${String(Math.floor(hour)).padStart(2, '0')}:00:00.000Z`)
+            ? (date, hour) =>
+                onSlotClick(`${date}T${String(Math.floor(hour)).padStart(2, '0')}:00:00.000Z`)
             : undefined,
           showWeekends: settings.showWeekends,
         });
@@ -201,7 +209,11 @@ export function CalendarView({
         ),
 
       // Vista principal
-      React.createElement('div', { className: 'flex-1 min-w-0 overflow-y-auto' }, renderActiveView())
+      React.createElement(
+        'div',
+        { className: 'flex-1 min-w-0 overflow-y-auto' },
+        renderActiveView()
+      )
     )
   );
 }

--- a/src/components/calendar/DayColumn.tsx
+++ b/src/components/calendar/DayColumn.tsx
@@ -1,4 +1,5 @@
 import { getHostReact } from '@coongro/plugin-sdk';
+
 import type { DayColumnProps } from '../../types/components.js';
 import { generateTimeSlots, diffMinutes } from '../../utils/date.js';
 import { EventCard } from '../event/EventCard.js';
@@ -9,7 +10,7 @@ const { useMemo } = React;
 const SLOT_HEIGHT = 56;
 
 export function DayColumn({
-  date,
+  date: _date,
   events,
   startHour = 8,
   endHour = 20,
@@ -67,47 +68,54 @@ export function DayColumn({
                 }
               : undefined,
           },
-          React.createElement('span', {
-            className: 'absolute inset-0 flex items-center justify-center text-sm font-semibold text-cg-accent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none select-none',
-          }, '+ Nuevo evento')
+          React.createElement(
+            'span',
+            {
+              className:
+                'absolute inset-0 flex items-center justify-center text-sm font-semibold text-cg-accent opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none select-none',
+            },
+            '+ Nuevo evento'
+          )
         )
       ),
 
       // Eventos posicionados
-      ...events.map((evt) => {
-        const evtStart = new Date(evt.start_at);
-        const evtStartMin = evtStart.getHours() * 60 + evtStart.getMinutes();
-        const gridStartMin = startHour * 60;
-        const gridEndMin = endHour * 60;
+      ...events
+        .map((evt) => {
+          const evtStart = new Date(evt.start_at);
+          const evtStartMin = evtStart.getHours() * 60 + evtStart.getMinutes();
+          const gridStartMin = startHour * 60;
+          const gridEndMin = endHour * 60;
 
-        if (evtStartMin < gridStartMin || evtStartMin >= gridEndMin) return null;
+          if (evtStartMin < gridStartMin || evtStartMin >= gridEndMin) return null;
 
-        const topOffset = ((evtStartMin - gridStartMin) / slotDuration) * SLOT_HEIGHT;
-        const duration = diffMinutes(evt.start_at, evt.end_at);
-        const height = (duration / slotDuration) * SLOT_HEIGHT;
+          const topOffset = ((evtStartMin - gridStartMin) / slotDuration) * SLOT_HEIGHT;
+          const duration = diffMinutes(evt.start_at, evt.end_at);
+          const height = (duration / slotDuration) * SLOT_HEIGHT;
 
-        return React.createElement(
-          'div',
-          {
-            key: evt.id,
-            className: 'absolute left-1 right-1 z-10',
-            style: {
-              top: `${Math.max(0, topOffset)}px`,
-              height: `${Math.max(SLOT_HEIGHT / 2, height)}px`,
+          return React.createElement(
+            'div',
+            {
+              key: evt.id,
+              className: 'absolute left-1 right-1 z-10',
+              style: {
+                top: `${Math.max(0, topOffset)}px`,
+                height: `${Math.max(SLOT_HEIGHT / 2, height)}px`,
+              },
             },
-          },
-          renderEvent
-            ? renderEvent(evt)
-            : React.createElement(EventCard, {
-                event: evt,
-                showTime: true,
-                showStatus: true,
-                showLocation: true,
-                onClick: onEventClick,
-                className: 'h-full rounded-sm overflow-hidden',
-              })
-        );
-      }).filter(Boolean)
+            renderEvent
+              ? renderEvent(evt)
+              : React.createElement(EventCard, {
+                  event: evt,
+                  showTime: true,
+                  showStatus: true,
+                  showLocation: true,
+                  onClick: onEventClick,
+                  className: 'h-full rounded-sm overflow-hidden',
+                })
+          );
+        })
+        .filter(Boolean)
     )
   );
 }

--- a/src/components/calendar/MiniCalendar.tsx
+++ b/src/components/calendar/MiniCalendar.tsx
@@ -1,4 +1,5 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
 import type { MiniCalendarProps } from '../../types/components.js';
 import {
   getMonthGridDays,
@@ -19,19 +20,25 @@ export function MiniCalendar({
   className = '',
 }: MiniCalendarProps) {
   const selected = selectedDate ? new Date(`${selectedDate}T00:00:00`) : null;
-  const [viewYear, setViewYear] = useState(() => selected?.getFullYear() ?? new Date().getFullYear());
+  const [viewYear, setViewYear] = useState(
+    () => selected?.getFullYear() ?? new Date().getFullYear()
+  );
   const [viewMonth, setViewMonth] = useState(() => selected?.getMonth() ?? new Date().getMonth());
 
   const days = useMemo(() => getMonthGridDays(viewYear, viewMonth), [viewYear, viewMonth]);
 
   const goNext = () => {
-    if (viewMonth === 11) { setViewMonth(0); setViewYear((y) => y + 1); }
-    else setViewMonth((m) => m + 1);
+    if (viewMonth === 11) {
+      setViewMonth(0);
+      setViewYear((y) => y + 1);
+    } else setViewMonth((m) => m + 1);
   };
 
   const goPrev = () => {
-    if (viewMonth === 0) { setViewMonth(11); setViewYear((y) => y - 1); }
-    else setViewMonth((m) => m - 1);
+    if (viewMonth === 0) {
+      setViewMonth(11);
+      setViewYear((y) => y - 1);
+    } else setViewMonth((m) => m - 1);
   };
 
   const weekDayHeaders = [1, 2, 3, 4, 5, 6, 0].map((d) => {
@@ -105,7 +112,8 @@ export function MiniCalendar({
           day.getDate(),
           dotCount > 0 &&
             React.createElement('span', {
-              className: 'absolute bottom-0.5 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-cg-accent',
+              className:
+                'absolute bottom-0.5 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full bg-cg-accent',
             })
         );
       })

--- a/src/components/calendar/MonthGrid.tsx
+++ b/src/components/calendar/MonthGrid.tsx
@@ -1,4 +1,5 @@
 import { getHostReact } from '@coongro/plugin-sdk';
+
 import type { MonthGridProps } from '../../types/components.js';
 import type { CalendarEvent } from '../../types/event.js';
 import { getMonthGridDays, getShortDayName, toDateString, isSameDay } from '../../utils/date.js';
@@ -107,11 +108,15 @@ export function MonthGrid({
               },
               day.getDate()
             ),
-            isCurrentMonth && React.createElement(
-              'span',
-              { className: 'inline-flex items-center gap-0.5 text-[10px] font-semibold text-cg-accent bg-cg-accent/10 border border-cg-accent/20 rounded px-1.5 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity select-none leading-none whitespace-nowrap' },
-              '+ Nuevo'
-            )
+            isCurrentMonth &&
+              React.createElement(
+                'span',
+                {
+                  className:
+                    'inline-flex items-center gap-0.5 text-[10px] font-semibold text-cg-accent bg-cg-accent/10 border border-cg-accent/20 rounded px-1.5 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity select-none leading-none whitespace-nowrap',
+                },
+                '+ Nuevo'
+              )
           ),
 
           // Eventos del día (máximo 3)

--- a/src/components/calendar/WeekGrid.tsx
+++ b/src/components/calendar/WeekGrid.tsx
@@ -1,4 +1,5 @@
 import { getHostReact } from '@coongro/plugin-sdk';
+
 import type { WeekGridProps } from '../../types/components.js';
 import type { CalendarEvent } from '../../types/event.js';
 import {
@@ -51,7 +52,6 @@ export function WeekGrid({
   }, [events]);
 
   const slotsPerHour = 60 / slotDuration;
-  const totalSlots = timeSlots.length;
 
   return React.createElement(
     'div',
@@ -62,14 +62,17 @@ export function WeekGrid({
       'div',
       { className: 'w-14 shrink-0 border-r border-cg-border' },
       // Header vacío (sticky)
-      React.createElement('div', { className: 'h-10 border-b border-cg-border sticky top-0 z-20 bg-cg-bg' }),
+      React.createElement('div', {
+        className: 'h-10 border-b border-cg-border sticky top-0 z-20 bg-cg-bg',
+      }),
       // Horas
       timeSlots.map((slot, i) =>
         React.createElement(
           'div',
           {
             key: slot,
-            className: 'text-[10px] text-cg-text-muted text-right pr-2 border-b border-cg-border/30',
+            className:
+              'text-[10px] text-cg-text-muted text-right pr-2 border-b border-cg-border/30',
             style: { height: `${SLOT_HEIGHT}px` },
           },
           i % slotsPerHour === 0 ? slot : ''
@@ -86,7 +89,10 @@ export function WeekGrid({
 
       return React.createElement(
         'div',
-        { key: dateStr, className: `flex-1 min-w-0 border-r border-cg-border last:border-r-0 ${isWeekend ? 'bg-cg-bg-secondary/30' : ''}` },
+        {
+          key: dateStr,
+          className: `flex-1 min-w-0 border-r border-cg-border last:border-r-0 ${isWeekend ? 'bg-cg-bg-secondary/30' : ''}`,
+        },
 
         // Header del día (sticky)
         React.createElement(
@@ -130,48 +136,56 @@ export function WeekGrid({
               },
               // Línea de acento en el top del slot
               React.createElement('div', {
-                className: 'absolute top-0 inset-x-0 h-0.5 bg-cg-accent opacity-0 group-hover:opacity-50 transition-opacity pointer-events-none rounded-full',
+                className:
+                  'absolute top-0 inset-x-0 h-0.5 bg-cg-accent opacity-0 group-hover:opacity-50 transition-opacity pointer-events-none rounded-full',
               }),
               // Chip de horario
-              React.createElement('span', {
-                className: 'absolute top-1 left-1 text-[10px] font-semibold text-cg-accent bg-cg-accent/10 border border-cg-accent/20 rounded px-1 py-0.5 leading-none opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none select-none',
-              }, slot)
+              React.createElement(
+                'span',
+                {
+                  className:
+                    'absolute top-1 left-1 text-[10px] font-semibold text-cg-accent bg-cg-accent/10 border border-cg-accent/20 rounded px-1 py-0.5 leading-none opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none select-none',
+                },
+                slot
+              )
             )
           ),
 
           // Eventos posicionados
-          ...dayEvents.map((evt) => {
-            const evtStart = new Date(evt.start_at);
-            const evtStartMin = evtStart.getHours() * 60 + evtStart.getMinutes();
-            const gridStartMin = startHour * 60;
-            const gridEndMin = endHour * 60;
+          ...dayEvents
+            .map((evt) => {
+              const evtStart = new Date(evt.start_at);
+              const evtStartMin = evtStart.getHours() * 60 + evtStart.getMinutes();
+              const gridStartMin = startHour * 60;
+              const gridEndMin = endHour * 60;
 
-            if (evtStartMin < gridStartMin || evtStartMin >= gridEndMin) return null;
+              if (evtStartMin < gridStartMin || evtStartMin >= gridEndMin) return null;
 
-            const topOffset = ((evtStartMin - gridStartMin) / slotDuration) * SLOT_HEIGHT;
-            const duration = diffMinutes(evt.start_at, evt.end_at);
-            const height = (duration / slotDuration) * SLOT_HEIGHT;
+              const topOffset = ((evtStartMin - gridStartMin) / slotDuration) * SLOT_HEIGHT;
+              const duration = diffMinutes(evt.start_at, evt.end_at);
+              const height = (duration / slotDuration) * SLOT_HEIGHT;
 
-            return React.createElement(
-              'div',
-              {
-                key: evt.id,
-                className: 'absolute left-0.5 right-0.5 z-10',
-                style: {
-                  top: `${Math.max(0, topOffset)}px`,
-                  height: `${Math.max(SLOT_HEIGHT / 2, height)}px`,
+              return React.createElement(
+                'div',
+                {
+                  key: evt.id,
+                  className: 'absolute left-0.5 right-0.5 z-10',
+                  style: {
+                    top: `${Math.max(0, topOffset)}px`,
+                    height: `${Math.max(SLOT_HEIGHT / 2, height)}px`,
+                  },
                 },
-              },
-              renderEvent
-                ? renderEvent(evt)
-                : React.createElement(EventCard, {
-                    event: evt,
-                    showTime: true,
-                    onClick: onEventClick,
-                    className: 'h-full rounded-sm overflow-hidden',
-                  })
-            );
-          }).filter(Boolean)
+                renderEvent
+                  ? renderEvent(evt)
+                  : React.createElement(EventCard, {
+                      event: evt,
+                      showTime: true,
+                      onClick: onEventClick,
+                      className: 'h-full rounded-sm overflow-hidden',
+                    })
+              );
+            })
+            .filter(Boolean)
         )
       );
     })

--- a/src/components/event/CalendarBadge.tsx
+++ b/src/components/event/CalendarBadge.tsx
@@ -1,4 +1,5 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
 import type { CalendarBadgeProps } from '../../types/components.js';
 
 const React = getHostReact();

--- a/src/components/event/CreateEventButton.tsx
+++ b/src/components/event/CreateEventButton.tsx
@@ -1,5 +1,7 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
 import type { CreateEventButtonProps } from '../../types/components.js';
+
 import { EventForm } from './EventForm.js';
 
 const React = getHostReact();
@@ -17,11 +19,7 @@ export function CreateEventButton({
   return React.createElement(
     React.Fragment,
     null,
-    React.createElement(
-      UI.Button,
-      { onClick: () => setOpen(true), className },
-      label
-    ),
+    React.createElement(UI.Button, { onClick: () => setOpen(true), className }, label),
     React.createElement(
       UI.FormDialog,
       {

--- a/src/components/event/EventCard.tsx
+++ b/src/components/event/EventCard.tsx
@@ -1,4 +1,5 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
 import type { EventCardProps } from '../../types/components.js';
 import { formatEventTime } from '../../utils/date.js';
 import { formatStatus, STATUS_BADGE_CLASSES } from '../../utils/labels.js';
@@ -44,11 +45,7 @@ export function EventCard({
     React.createElement(
       'div',
       { className: 'flex-1 min-w-0' },
-      React.createElement(
-        'div',
-        { className: 'font-medium truncate' },
-        event.title
-      ),
+      React.createElement('div', { className: 'font-medium truncate' }, event.title),
       showTime &&
         !event.all_day &&
         React.createElement(
@@ -56,7 +53,8 @@ export function EventCard({
           { className: 'text-cg-text-muted' },
           `${formatEventTime(event.start_at)} - ${formatEventTime(event.end_at)}`
         ),
-      showLocation && event.location &&
+      showLocation &&
+        event.location &&
         React.createElement(
           'div',
           { className: 'flex items-center gap-1 text-cg-text-muted mt-0.5' },
@@ -68,7 +66,10 @@ export function EventCard({
     showStatus &&
       React.createElement(
         UI.Badge,
-        { variant: 'outline', className: `text-[10px] shrink-0 ${STATUS_BADGE_CLASSES[event.status] ?? ''}` },
+        {
+          variant: 'outline',
+          className: `text-[10px] shrink-0 ${STATUS_BADGE_CLASSES[event.status] ?? ''}`,
+        },
         formatStatus(event.status)
       ),
     badge

--- a/src/components/event/EventDetail.tsx
+++ b/src/components/event/EventDetail.tsx
@@ -1,6 +1,7 @@
 import { getHostReact, getHostUI, useViewContributions } from '@coongro/plugin-sdk';
-import type { EventDetailProps } from '../../types/components.js';
+
 import { useEvent } from '../../hooks/useEvent.js';
+import type { EventDetailProps } from '../../types/components.js';
 import { formatEventDateTime } from '../../utils/date.js';
 import { formatStatus } from '../../utils/labels.js';
 import { PinIcon, CalendarIcon } from '../internal/icons.js';
@@ -19,7 +20,9 @@ export function EventDetail({
 }: EventDetailProps) {
   const { event, loading, error } = useEvent(eventId);
 
-  const { sections: entityInfoSections } = useViewContributions('calendar.event-detail.entity-info');
+  const { sections: entityInfoSections } = useViewContributions(
+    'calendar.event-detail.entity-info'
+  );
   const { sections: extraSections } = useViewContributions('calendar.event-detail.sections');
   const { sections: actionSlots } = useViewContributions('calendar.event-detail.actions');
 

--- a/src/components/event/EventForm.tsx
+++ b/src/components/event/EventForm.tsx
@@ -1,16 +1,17 @@
 import { getHostReact, getHostUI, useViewContributions } from '@coongro/plugin-sdk';
-import type { EventFormProps } from '../../types/components.js';
-import type { EventCreateData } from '../../types/event.js';
+
+import { useCalendars } from '../../hooks/useCalendars.js';
+import { useCalendarSettings } from '../../hooks/useCalendarSettings.js';
 import { useEvent } from '../../hooks/useEvent.js';
 import { useEventMutations } from '../../hooks/useEventMutations.js';
-import { useCalendarSettings } from '../../hooks/useCalendarSettings.js';
-import { useCalendars } from '../../hooks/useCalendars.js';
 import { useEventTypes } from '../../hooks/useEventTypes.js';
-import { STATUS_LABELS, toSelectOptions } from '../../utils/labels.js';
+import type { EventFormProps } from '../../types/components.js';
+import type { EventCreateData } from '../../types/event.js';
 import { addMinutes, toDateString } from '../../utils/date.js';
+import { STATUS_LABELS, toSelectOptions } from '../../utils/labels.js';
+import { ColorPicker } from '../internal/ColorPicker.js';
 import { DatePicker } from '../internal/DatePicker.js';
 import { TimePicker } from '../internal/TimePicker.js';
-import { ColorPicker } from '../internal/ColorPicker.js';
 
 const React = getHostReact();
 const UI = getHostUI();
@@ -24,7 +25,7 @@ export function EventForm({
   eventId,
   defaults = {},
   hiddenFields = [],
-  hiddenSections = [],
+  hiddenSections: _hiddenSections = [],
   calendarOptions,
   eventTypeOptions,
   renderBeforeFields,
@@ -96,7 +97,7 @@ export function EventForm({
     async (e: { preventDefault: () => void }) => {
       e.preventDefault();
       const data = formData as unknown as EventCreateData;
-      const result = isEdit ? await update(eventId!, data) : await create(data);
+      const result = isEdit ? await update(eventId, data) : await create(data);
       if (result) onSuccess?.(result);
     },
     [formData, isEdit, eventId, create, update, onSuccess]
@@ -238,11 +239,7 @@ export function EventForm({
       React.createElement(
         'div',
         { className: 'flex flex-col gap-1.5' },
-        React.createElement(
-          UI.Label,
-          null,
-          `Tipo${settings.requireType ? ' *' : ''}`
-        ),
+        React.createElement(UI.Label, null, `Tipo${settings.requireType ? ' *' : ''}`),
         React.createElement(
           UI.Select,
           {

--- a/src/components/event/EventList.tsx
+++ b/src/components/event/EventList.tsx
@@ -1,8 +1,9 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
-import type { EventListProps } from '../../types/components.js';
+
 import { useEvents } from '../../hooks/useEvents.js';
+import type { EventListProps } from '../../types/components.js';
 import { formatEventDateTime } from '../../utils/date.js';
-import { formatStatus, STATUS_LABELS, STATUS_BADGE_CLASSES } from '../../utils/labels.js';
+import { formatStatus, STATUS_BADGE_CLASSES } from '../../utils/labels.js';
 import { PinIcon, CalendarIcon } from '../internal/icons.js';
 
 const React = getHostReact();
@@ -19,17 +20,10 @@ export function EventList({
   emptyStateAction,
   className = '',
 }: EventListProps) {
-  const {
-    data,
-    loading,
-    error,
-    setFilters,
-    setSort,
-    pagination,
-    nextPage,
-    prevPage,
-    goToPage,
-  } = useEvents({ ...initialFilters, pageSize });
+  const { data, loading, error, setFilters, pagination, goToPage } = useEvents({
+    ...initialFilters,
+    pageSize,
+  });
 
   const [searchValue, setSearchValue] = useState('');
 
@@ -44,8 +38,7 @@ export function EventList({
     [setFilters, initialFilters]
   );
 
-  const getStatusLabel = (status: string) =>
-    statusConfig?.[status]?.label ?? formatStatus(status);
+  const getStatusLabel = (status: string) => statusConfig?.[status]?.label ?? formatStatus(status);
 
   return React.createElement(
     'div',
@@ -79,8 +72,7 @@ export function EventList({
           React.createElement(UI.TableHead, null, 'Título'),
           React.createElement(UI.TableHead, null, 'Fecha'),
           React.createElement(UI.TableHead, null, 'Estado'),
-          extraActions.length > 0 &&
-            React.createElement(UI.TableHead, { className: 'w-10' })
+          extraActions.length > 0 && React.createElement(UI.TableHead, { className: 'w-10' })
         )
       ),
       React.createElement(
@@ -91,9 +83,21 @@ export function EventList({
               React.createElement(
                 UI.TableRow,
                 { key: `skeleton-${i}` },
-                React.createElement(UI.TableCell, null, React.createElement(UI.Skeleton, { className: 'h-4 w-32' })),
-                React.createElement(UI.TableCell, null, React.createElement(UI.Skeleton, { className: 'h-4 w-24' })),
-                React.createElement(UI.TableCell, null, React.createElement(UI.Skeleton, { className: 'h-4 w-16' }))
+                React.createElement(
+                  UI.TableCell,
+                  null,
+                  React.createElement(UI.Skeleton, { className: 'h-4 w-32' })
+                ),
+                React.createElement(
+                  UI.TableCell,
+                  null,
+                  React.createElement(UI.Skeleton, { className: 'h-4 w-24' })
+                ),
+                React.createElement(
+                  UI.TableCell,
+                  null,
+                  React.createElement(UI.Skeleton, { className: 'h-4 w-16' })
+                )
               )
             )
           : data.length === 0
@@ -136,7 +140,10 @@ export function EventList({
                         evt.location &&
                           React.createElement(
                             'div',
-                            { className: 'flex items-center gap-1 text-xs text-cg-text-muted font-normal' },
+                            {
+                              className:
+                                'flex items-center gap-1 text-xs text-cg-text-muted font-normal',
+                            },
                             React.createElement(PinIcon, null),
                             React.createElement('span', { className: 'truncate' }, evt.location)
                           )

--- a/src/components/event/EventPicker.tsx
+++ b/src/components/event/EventPicker.tsx
@@ -1,8 +1,9 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
-import type { EventPickerProps } from '../../types/components.js';
-import type { CalendarEvent } from '../../types/event.js';
+
 import { useEvent } from '../../hooks/useEvent.js';
 import { useEvents } from '../../hooks/useEvents.js';
+import type { EventPickerProps } from '../../types/components.js';
+import type { CalendarEvent } from '../../types/event.js';
 import { formatEventDateTime } from '../../utils/date.js';
 
 const React = getHostReact();

--- a/src/components/event/EventStats.tsx
+++ b/src/components/event/EventStats.tsx
@@ -1,6 +1,7 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
-import type { EventStatsProps } from '../../types/components.js';
+
 import { useEventStats } from '../../hooks/useEventStats.js';
+import type { EventStatsProps } from '../../types/components.js';
 import { formatStatus } from '../../utils/labels.js';
 
 const React = getHostReact();
@@ -12,18 +13,18 @@ const STATUS_COLORS_HEX: Record<string, string> = {
   confirmed: '#22c55e',
   completed: '#94a3b8',
   cancelled: '#ef4444',
-  no_show:   '#f59e0b',
+  no_show: '#f59e0b',
   tentative: '#10b981',
 };
 
 // Clases de texto y fondo por estado (para Tailwind estático)
 const STATUS_CARD_CLASSES: Record<string, { text: string; bg: string }> = {
-  scheduled: { text: 'text-cg-info',        bg: 'bg-cg-info-bg' },
-  confirmed: { text: 'text-cg-success',     bg: 'bg-cg-success-bg' },
-  completed: { text: 'text-cg-text-muted',  bg: 'bg-cg-bg-secondary' },
-  cancelled: { text: 'text-cg-danger',      bg: 'bg-cg-danger-bg' },
-  no_show:   { text: 'text-cg-warning-text',bg: 'bg-cg-warning-bg' },
-  tentative: { text: 'text-cg-accent',      bg: 'bg-cg-accent/10' },
+  scheduled: { text: 'text-cg-info', bg: 'bg-cg-info-bg' },
+  confirmed: { text: 'text-cg-success', bg: 'bg-cg-success-bg' },
+  completed: { text: 'text-cg-text-muted', bg: 'bg-cg-bg-secondary' },
+  cancelled: { text: 'text-cg-danger', bg: 'bg-cg-danger-bg' },
+  no_show: { text: 'text-cg-warning-text', bg: 'bg-cg-warning-bg' },
+  tentative: { text: 'text-cg-accent', bg: 'bg-cg-accent/10' },
 };
 
 export function EventStats({ from, to, className = '' }: EventStatsProps) {
@@ -84,7 +85,10 @@ export function EventStats({ from, to, className = '' }: EventStatsProps) {
         ),
         React.createElement(
           'div',
-          { className: 'text-[11px] font-semibold text-cg-text-muted uppercase tracking-wide mt-1.5' },
+          {
+            className:
+              'text-[11px] font-semibold text-cg-text-muted uppercase tracking-wide mt-1.5',
+          },
           'Total'
         )
       ),

--- a/src/components/event/UpcomingEvents.tsx
+++ b/src/components/event/UpcomingEvents.tsx
@@ -1,6 +1,7 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
-import type { UpcomingEventsProps } from '../../types/components.js';
+
 import { useUpcomingEvents } from '../../hooks/useUpcomingEvents.js';
+import type { UpcomingEventsProps } from '../../types/components.js';
 import { formatEventDate, formatEventTime } from '../../utils/date.js';
 import { formatStatus } from '../../utils/labels.js';
 
@@ -14,7 +15,7 @@ export function UpcomingEvents({
   emptyMessage = 'No hay próximos eventos',
   className = '',
 }: UpcomingEventsProps) {
-  const { data, loading, error } = useUpcomingEvents({ limit, calendarIds });
+  const { data, loading } = useUpcomingEvents({ limit, calendarIds });
 
   if (loading) {
     return React.createElement(

--- a/src/components/internal/ColorPicker.tsx
+++ b/src/components/internal/ColorPicker.tsx
@@ -1,4 +1,5 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
 import type { ColorPickerProps } from '../../types/components.js';
 
 const React = getHostReact();
@@ -6,9 +7,21 @@ const UI = getHostUI();
 const { useState } = React;
 
 const DEFAULT_COLORS = [
-  '#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6',
-  '#EC4899', '#06B6D4', '#84CC16', '#F97316', '#6366F1',
-  '#14B8A6', '#A855F7', '#E11D48', '#0EA5E9', '#22C55E',
+  '#3B82F6',
+  '#10B981',
+  '#F59E0B',
+  '#EF4444',
+  '#8B5CF6',
+  '#EC4899',
+  '#06B6D4',
+  '#84CC16',
+  '#F97316',
+  '#6366F1',
+  '#14B8A6',
+  '#A855F7',
+  '#E11D48',
+  '#0EA5E9',
+  '#22C55E',
   '#FACC15',
 ];
 
@@ -47,7 +60,9 @@ export function ColorPicker({
             key: color,
             type: 'button',
             className: `w-7 h-7 rounded-full border-2 transition-transform hover:scale-110 ${
-              value === color ? 'border-cg-border-strong ring-2 ring-cg-accent' : 'border-transparent'
+              value === color
+                ? 'border-cg-border-strong ring-2 ring-cg-accent'
+                : 'border-transparent'
             }`,
             style: { backgroundColor: color },
             onClick: () => {

--- a/src/components/internal/DatePicker.tsx
+++ b/src/components/internal/DatePicker.tsx
@@ -1,4 +1,5 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
 import type { DatePickerProps } from '../../types/components.js';
 import {
   getMonthGridDays,
@@ -50,11 +51,8 @@ export function DatePicker({
     }
   };
 
-  const isDisabled = (date: Date): boolean => {
-    if (minDate && date < new Date(minDate)) return true;
-    if (maxDate && date > new Date(maxDate)) return true;
-    return false;
-  };
+  const isDisabled = (date: Date): boolean =>
+    (!!minDate && date < new Date(minDate)) || (!!maxDate && date > new Date(maxDate));
 
   const handleSelect = (date: Date) => {
     if (isDisabled(date)) return;
@@ -137,11 +135,7 @@ export function DatePicker({
               type: 'button',
               disabled,
               className: `w-8 h-8 text-sm rounded-full transition-colors ${
-                isSelected
-                  ? 'bg-cg-accent text-white'
-                  : isToday
-                    ? 'bg-cg-bg-hover font-bold'
-                    : ''
+                isSelected ? 'bg-cg-accent text-white' : isToday ? 'bg-cg-bg-hover font-bold' : ''
               } ${!isCurrentMonth ? 'text-cg-text-muted opacity-40' : ''} ${
                 disabled ? 'opacity-20 cursor-not-allowed' : 'hover:bg-cg-bg-hover cursor-pointer'
               }`,

--- a/src/components/internal/TimePicker.tsx
+++ b/src/components/internal/TimePicker.tsx
@@ -1,4 +1,5 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
+
 import type { TimePickerProps } from '../../types/components.js';
 import { generateTimeSlots } from '../../utils/date.js';
 

--- a/src/hooks/useCalendarMutations.ts
+++ b/src/hooks/useCalendarMutations.ts
@@ -1,4 +1,5 @@
 import { getHostReact, actions, usePlugin } from '@coongro/plugin-sdk';
+
 import type { CalendarGroup, CalendarCreateData, CalendarUpdateData } from '../types/calendar.js';
 
 const React = getHostReact();

--- a/src/hooks/useCalendarSettings.ts
+++ b/src/hooks/useCalendarSettings.ts
@@ -1,6 +1,7 @@
 import { useSettings } from '@coongro/plugin-sdk';
-import { CALENDAR_SETTINGS } from '../utils/settings.js';
+
 import type { CalendarViewMode } from '../types/components.js';
+import { CALENDAR_SETTINGS } from '../utils/settings.js';
 
 export interface CalendarSettings {
   defaultView: CalendarViewMode;

--- a/src/hooks/useCalendars.ts
+++ b/src/hooks/useCalendars.ts
@@ -1,4 +1,5 @@
 import { getHostReact, actions } from '@coongro/plugin-sdk';
+
 import type { CalendarGroup } from '../types/calendar.js';
 
 const React = getHostReact();

--- a/src/hooks/useDateNavigation.ts
+++ b/src/hooks/useDateNavigation.ts
@@ -1,4 +1,5 @@
 import { getHostReact } from '@coongro/plugin-sdk';
+
 import type { CalendarViewMode } from '../types/components.js';
 import {
   getWeekStart,
@@ -25,9 +26,7 @@ export interface UseDateNavigationResult {
   title: string;
 }
 
-export function useDateNavigation(
-  initialView: CalendarViewMode = 'week'
-): UseDateNavigationResult {
+export function useDateNavigation(initialView: CalendarViewMode = 'week'): UseDateNavigationResult {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [view, setView] = useState<CalendarViewMode>(initialView);
 

--- a/src/hooks/useEvent.ts
+++ b/src/hooks/useEvent.ts
@@ -1,4 +1,5 @@
 import { getHostReact, actions } from '@coongro/plugin-sdk';
+
 import type { CalendarEvent } from '../types/event.js';
 
 const React = getHostReact();
@@ -32,10 +33,9 @@ export function useEvent(eventId?: string | null): UseEventResult {
     setLoading(true);
     setError(null);
     try {
-      const result = await actions.execute<CalendarEvent | undefined>(
-        'calendar.events.getById',
-        { id: eventId }
-      );
+      const result = await actions.execute<CalendarEvent | undefined>('calendar.events.getById', {
+        id: eventId,
+      });
       if (!mountedRef.current) return;
       setEvent(result ?? null);
     } catch (err) {

--- a/src/hooks/useEventMutations.ts
+++ b/src/hooks/useEventMutations.ts
@@ -1,4 +1,5 @@
 import { getHostReact, actions, usePlugin } from '@coongro/plugin-sdk';
+
 import type { CalendarEvent, EventCreateData, EventUpdateData } from '../types/event.js';
 
 const React = getHostReact();

--- a/src/hooks/useEventTypeMutations.ts
+++ b/src/hooks/useEventTypeMutations.ts
@@ -1,4 +1,5 @@
 import { getHostReact, actions, usePlugin } from '@coongro/plugin-sdk';
+
 import type { EventType, EventTypeCreateData, EventTypeUpdateData } from '../types/event-type.js';
 
 const React = getHostReact();

--- a/src/hooks/useEventTypes.ts
+++ b/src/hooks/useEventTypes.ts
@@ -1,4 +1,5 @@
 import { getHostReact, actions } from '@coongro/plugin-sdk';
+
 import type { EventType } from '../types/event-type.js';
 
 const React = getHostReact();

--- a/src/hooks/useEvents.ts
+++ b/src/hooks/useEvents.ts
@@ -1,4 +1,5 @@
 import { getHostReact, actions } from '@coongro/plugin-sdk';
+
 import type { CalendarEvent } from '../types/event.js';
 import type { EventFilters, SortDirection } from '../types/filters.js';
 

--- a/src/hooks/useEventsByEntity.ts
+++ b/src/hooks/useEventsByEntity.ts
@@ -1,4 +1,5 @@
 import { getHostReact, actions } from '@coongro/plugin-sdk';
+
 import type { CalendarEvent } from '../types/event.js';
 
 const React = getHostReact();

--- a/src/hooks/useUpcomingEvents.ts
+++ b/src/hooks/useUpcomingEvents.ts
@@ -1,4 +1,5 @@
 import { getHostReact, actions } from '@coongro/plugin-sdk';
+
 import type { CalendarEvent } from '../types/event.js';
 
 const React = getHostReact();

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,16 +18,8 @@ export type {
   EventUpdateData,
   EventStatus,
 } from './types/event.js';
-export type {
-  CalendarGroup,
-  CalendarCreateData,
-  CalendarUpdateData,
-} from './types/calendar.js';
-export type {
-  EventType,
-  EventTypeCreateData,
-  EventTypeUpdateData,
-} from './types/event-type.js';
+export type { CalendarGroup, CalendarCreateData, CalendarUpdateData } from './types/calendar.js';
+export type { EventType, EventTypeCreateData, EventTypeUpdateData } from './types/event-type.js';
 export type { EventFilters, SortDirection } from './types/filters.js';
 export type {
   CalendarViewMode,

--- a/src/repositories/calendar.repository.ts
+++ b/src/repositories/calendar.repository.ts
@@ -1,5 +1,6 @@
-import { eq, and, isNull, not } from 'drizzle-orm';
 import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
+import { eq, and, isNull } from 'drizzle-orm';
+
 import { calendarTable } from '../schema/calendar.js';
 import type { CalendarRow, NewCalendarRow } from '../schema/calendar.js';
 
@@ -29,7 +30,13 @@ export class CalendarRepository {
     return this.db.ormQuery((tx) => tx.insert(calendarTable).values(row).returning());
   }
 
-  async update({ id, data }: { id: string; data: Partial<NewCalendarRow> }): Promise<CalendarRow[]> {
+  async update({
+    id,
+    data,
+  }: {
+    id: string;
+    data: Partial<NewCalendarRow>;
+  }): Promise<CalendarRow[]> {
     return this.db.ormQuery((tx) =>
       tx
         .update(calendarTable)
@@ -70,7 +77,10 @@ export class CalendarRepository {
     return this.db.ormQuery((tx) =>
       tx
         .update(calendarTable)
-        .set({ is_visible: !existing.is_visible, updated_at: new Date().toISOString() } as Partial<CalendarRow>)
+        .set({
+          is_visible: !existing.is_visible,
+          updated_at: new Date().toISOString(),
+        } as Partial<CalendarRow>)
         .where(eq(calendarTable.id, id))
         .returning()
     );

--- a/src/repositories/event-type.repository.ts
+++ b/src/repositories/event-type.repository.ts
@@ -1,5 +1,7 @@
-import { eq, and, or, ilike, isNull } from 'drizzle-orm';
 import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
+import { eq, and, or, ilike, isNull } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+
 import { eventTypeTable } from '../schema/event-type.js';
 import type { EventTypeRow, NewEventTypeRow } from '../schema/event-type.js';
 
@@ -76,7 +78,7 @@ export class EventTypeRepository {
     includeDeleted?: boolean;
   }): Promise<EventTypeRow[]> {
     return this.db.ormQuery((tx) => {
-      const conditions = [];
+      const conditions: (SQL | undefined)[] = [];
 
       if (!includeDeleted) {
         conditions.push(isNull(eventTypeTable.deleted_at));
@@ -85,7 +87,7 @@ export class EventTypeRepository {
       if (query) {
         const pattern = `%${query}%`;
         conditions.push(
-          or(ilike(eventTypeTable.name, pattern), ilike(eventTypeTable.description, pattern))!
+          or(ilike(eventTypeTable.name, pattern), ilike(eventTypeTable.description, pattern))
         );
       }
 

--- a/src/repositories/event.repository.ts
+++ b/src/repositories/event.repository.ts
@@ -1,6 +1,7 @@
+import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
 import { eq, and, or, ilike, isNull, gte, lte, asc, desc, sql, inArray } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';
-import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
+
 import { eventTable } from '../schema/event.js';
 import type { EventRow, NewEventRow } from '../schema/event.js';
 
@@ -100,7 +101,7 @@ export class EventRepository {
       entityType,
       from,
       to,
-      tags,
+      tags: _tags,
       includeDeleted,
       limit,
       offset,
@@ -122,7 +123,7 @@ export class EventRepository {
             ilike(eventTable.title, pattern),
             ilike(eventTable.description, pattern),
             ilike(eventTable.notes, pattern)
-          )!
+          )
         );
       }
 
@@ -293,7 +294,11 @@ export class EventRepository {
     return this.db.ormQuery((tx) =>
       tx
         .update(eventTable)
-        .set({ start_at: startAt, end_at: endAt, updated_at: new Date().toISOString() } as Partial<EventRow>)
+        .set({
+          start_at: startAt,
+          end_at: endAt,
+          updated_at: new Date().toISOString(),
+        } as Partial<EventRow>)
         .where(eq(eventTable.id, id))
         .returning()
     );
@@ -335,10 +340,7 @@ export class EventRepository {
     );
   }
 
-  async countByCalendar({
-    from,
-    to,
-  }: { from?: string; to?: string } = {}): Promise<CountResult[]> {
+  async countByCalendar({ from, to }: { from?: string; to?: string } = {}): Promise<CountResult[]> {
     return this.db.ormQuery((tx) => {
       const conditions: SQL[] = [isNull(eventTable.deleted_at)];
       if (from) conditions.push(gte(eventTable.start_at, from));

--- a/src/schema/calendar.ts
+++ b/src/schema/calendar.ts
@@ -1,5 +1,5 @@
-import { boolean, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
+import { boolean, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 export const calendarTable = pgTable('module_calendar_calendars', {
   id: uuid('id').primaryKey().notNull(),
@@ -10,8 +10,12 @@ export const calendarTable = pgTable('module_calendar_calendars', {
   is_default: boolean('is_default').notNull(),
   metadata: jsonb('metadata'),
   deleted_at: timestamp('deleted_at', { mode: 'string' }),
-  created_at: timestamp('created_at', { mode: 'string' }).notNull().default(sql`now()`),
-  updated_at: timestamp('updated_at', { mode: 'string' }).notNull().default(sql`now()`),
+  created_at: timestamp('created_at', { mode: 'string' })
+    .notNull()
+    .default(sql`now()`),
+  updated_at: timestamp('updated_at', { mode: 'string' })
+    .notNull()
+    .default(sql`now()`),
 });
 
 export type CalendarRow = typeof calendarTable.$inferSelect;

--- a/src/schema/event-type.ts
+++ b/src/schema/event-type.ts
@@ -1,5 +1,5 @@
-import { integer, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
+import { integer, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 export const eventTypeTable = pgTable('module_calendar_event_types', {
   id: uuid('id').primaryKey().notNull(),
@@ -9,8 +9,12 @@ export const eventTypeTable = pgTable('module_calendar_event_types', {
   description: text('description'),
   metadata: jsonb('metadata'),
   deleted_at: timestamp('deleted_at', { mode: 'string' }),
-  created_at: timestamp('created_at', { mode: 'string' }).notNull().default(sql`now()`),
-  updated_at: timestamp('updated_at', { mode: 'string' }).notNull().default(sql`now()`),
+  created_at: timestamp('created_at', { mode: 'string' })
+    .notNull()
+    .default(sql`now()`),
+  updated_at: timestamp('updated_at', { mode: 'string' })
+    .notNull()
+    .default(sql`now()`),
 });
 
 export type EventTypeRow = typeof eventTypeTable.$inferSelect;

--- a/src/schema/event.ts
+++ b/src/schema/event.ts
@@ -1,5 +1,5 @@
-import { boolean, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { sql } from 'drizzle-orm';
+import { boolean, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 
 export const eventTable = pgTable('module_calendar_events', {
   id: uuid('id').primaryKey().notNull(),
@@ -24,8 +24,12 @@ export const eventTable = pgTable('module_calendar_events', {
   notes: text('notes'),
   is_active: boolean('is_active').notNull(),
   deleted_at: timestamp('deleted_at', { mode: 'string' }),
-  created_at: timestamp('created_at', { mode: 'string' }).notNull().default(sql`now()`),
-  updated_at: timestamp('updated_at', { mode: 'string' }).notNull().default(sql`now()`),
+  created_at: timestamp('created_at', { mode: 'string' })
+    .notNull()
+    .default(sql`now()`),
+  updated_at: timestamp('updated_at', { mode: 'string' })
+    .notNull()
+    .default(sql`now()`),
 });
 
 export type EventRow = typeof eventTable.$inferSelect;

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,8 +1,9 @@
 import type { ReactNode } from 'react';
-import type { CalendarEvent, EventCreateData, EventStatus } from './event.js';
+
 import type { CalendarGroup } from './calendar.js';
 import type { EventType } from './event-type.js';
-import type { EventFilters, SortDirection } from './filters.js';
+import type { CalendarEvent, EventCreateData } from './event.js';
+import type { EventFilters } from './filters.js';
 
 // --- Calendario ---
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,10 +1,6 @@
 export type { CalendarEvent, EventCreateData, EventUpdateData, EventStatus } from './event.js';
 export type { CalendarGroup, CalendarCreateData, CalendarUpdateData } from './calendar.js';
-export type {
-  EventType,
-  EventTypeCreateData,
-  EventTypeUpdateData,
-} from './event-type.js';
+export type { EventType, EventTypeCreateData, EventTypeUpdateData } from './event-type.js';
 export type { EventFilters, SortDirection } from './filters.js';
 export type {
   CalendarViewMode,

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -129,9 +129,11 @@ export function toDateString(date: Date): string {
 
 /** Compara dos fechas ignorando hora */
 export function isSameDay(a: Date, b: Date): boolean {
-  return a.getFullYear() === b.getFullYear() &&
+  return (
+    a.getFullYear() === b.getFullYear() &&
     a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate();
+    a.getDate() === b.getDate()
+  );
 }
 
 /** Diferencia en minutos entre dos ISO strings */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,10 +1,5 @@
 export { CALENDAR_SETTINGS } from './settings.js';
-export {
-  STATUS_LABELS,
-  STATUS_COLORS,
-  formatStatus,
-  toSelectOptions,
-} from './labels.js';
+export { STATUS_LABELS, STATUS_COLORS, formatStatus, toSelectOptions } from './labels.js';
 export {
   formatEventDate,
   formatEventTime,
@@ -24,9 +19,5 @@ export {
   diffMinutes,
   addMinutes,
 } from './date.js';
-export {
-  parseRRule,
-  toRRule,
-  formatRecurrence,
-} from './recurrence.js';
+export { parseRRule, toRRule, formatRecurrence } from './recurrence.js';
 export type { RecurrenceRule } from './recurrence.js';

--- a/src/utils/labels.ts
+++ b/src/utils/labels.ts
@@ -17,12 +17,12 @@ export const STATUS_COLORS: Record<string, string> = {
 };
 
 export const STATUS_BADGE_CLASSES: Record<string, string> = {
-  scheduled:  'bg-cg-info-bg text-cg-info border-cg-info-border',
-  confirmed:  'bg-cg-success-bg text-cg-success border-cg-success-border',
-  completed:  'bg-cg-bg-secondary text-cg-text-muted border-cg-border',
-  cancelled:  'bg-cg-danger-bg text-cg-danger border-cg-danger-border',
-  no_show:    'bg-cg-warning-bg text-cg-warning-text border-cg-warning-border',
-  tentative:  'bg-cg-accent/10 text-cg-accent border-cg-accent/30',
+  scheduled: 'bg-cg-info-bg text-cg-info border-cg-info-border',
+  confirmed: 'bg-cg-success-bg text-cg-success border-cg-success-border',
+  completed: 'bg-cg-bg-secondary text-cg-text-muted border-cg-border',
+  cancelled: 'bg-cg-danger-bg text-cg-danger border-cg-danger-border',
+  no_show: 'bg-cg-warning-bg text-cg-warning-text border-cg-warning-border',
+  tentative: 'bg-cg-accent/10 text-cg-accent border-cg-accent/30',
 };
 
 export function formatStatus(status: string): string {


### PR DESCRIPTION
Closes #1

## Changes
- Run Prettier on all 55 files with formatting issues
- Remove unused imports: `not`, `STATUS_LABELS`, `EventStatus`, `SortDirection`
- Remove unused variables: `colCount`, `totalSlots`, `hiddenSections`, `tags`, `error`, `setSort`, `nextPage`, `prevPage`
- Prefix unused required params with `_` (e.g. `date` → `_date` in DayColumn)
- Fix `sonarjs/prefer-single-boolean-return` in `DatePicker.isDisabled`
- Type `conditions` array as `(SQL | undefined)[]` to fix unsafe any spread in `event-type.repository`

## Testing
- [x] `npm run quality` passes (0 errors, 28 warnings)
- [x] `npm publish --registry http://localhost:4873/` runs `prepublishOnly` successfully (quality + build pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization through import reordering and standardized formatting across components and utilities.
  * Removed unused variables and dead code to enhance code cleanliness.
  * Simplified conditional logic expressions for better readability.
  * Cleaned up type handling by removing unnecessary non-null assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->