### PR TITLE
ci: Fix CI lockfile integrity con múltiples registries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
           echo "@coongro:registry=${{ secrets.STAGING_VERDACCIO_URL }}" > .npmrc
           echo "//${{ secrets.STAGING_VERDACCIO_URL_HOST }}/:_authToken=${{ secrets.STAGING_VERDACCIO_TOKEN }}" >> .npmrc
 
-      - run: npm install
+      - name: Install dependencies
+        run: |
+          rm -f package-lock.json
+          npm install
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,10 @@ jobs:
           echo "@coongro:registry=${{ secrets.STAGING_VERDACCIO_URL }}" > .npmrc
           echo "//${{ secrets.STAGING_VERDACCIO_URL_HOST }}/:_authToken=${{ secrets.STAGING_VERDACCIO_TOKEN }}" >> .npmrc
 
-      - run: npm install
+      - name: Install dependencies
+        run: |
+          rm -f package-lock.json
+          npm install
       - run: npm run build
 
       - name: Publish to production Verdaccio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,10 @@ jobs:
           echo "@coongro:registry=${{ secrets.STAGING_VERDACCIO_URL }}" > .npmrc
           echo "//${{ secrets.STAGING_VERDACCIO_URL_HOST }}/:_authToken=${{ secrets.STAGING_VERDACCIO_TOKEN }}" >> .npmrc
 
-      - run: npm install
+      - name: Install dependencies
+        run: |
+          rm -f package-lock.json
+          npm install
       - run: npm run build
 
       - name: Create Release PR or Publish


### PR DESCRIPTION
Closes #11

## Changes
- Modified `ci.yml`, `release.yml`, and `publish.yml` to regenerate `package-lock.json` before `npm install`
- This avoids EINTEGRITY errors when CI uses a different registry than local dev

## Testing
- [ ] Verify CI passes with the new install step
- [ ] Confirm lockfile regeneration does not affect dependency resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation process across CI/CD pipelines to ensure consistent dependency resolution for build, publish, and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->