### PR TITLE
fix: use workspace:* for plugin-sdk devDependency

### DIFF
--- a/.changeset/fix-plugin-sdk-workspace.md
+++ b/.changeset/fix-plugin-sdk-workspace.md
@@ -1,0 +1,8 @@
+---
+"@coongro/calendar": patch
+---
+
+fix: use workspace protocol for plugin-sdk devDependency
+
+Prevents pnpm install from failing in the monorepo by resolving
+plugin-sdk from the workspace instead of npm public registry.

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",
-    "@coongro/plugin-sdk": ">=0.14.0",
+    "@coongro/plugin-sdk": "workspace:*",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.57.1",


### PR DESCRIPTION
Closes #14

## Changes
- Change `@coongro/plugin-sdk` devDependency from `>=0.14.0` to `workspace:*`
- peerDependency remains `>=0.1.0` (unchanged — this is what gets published)

## Why
`pnpm install` in the monorepo fails because it tries to resolve `@coongro/plugin-sdk` from npm public registry (where it doesn't exist). With `workspace:*`, pnpm resolves it from the workspace. On `npm publish`, pnpm automatically replaces `workspace:*` with the actual version.

## Test plan
- [ ] `pnpm install` in monorepo completes without `ERR_PNPM_FETCH_404` for plugin-sdk
- [ ] `pnpm build` for calendar still works
- [ ] Plugin publishes correctly to Verdaccio (workspace:* → real version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved installation issues in the monorepo environment by updating dependency resolution configuration for the plugin-sdk package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->