### PR TITLE
feat: Export pickers and fix cross-plugin CSS

### DIFF
--- a/src/components/internal/DatePicker.tsx
+++ b/src/components/internal/DatePicker.tsx
@@ -108,7 +108,7 @@ export function DatePicker({
       // Headers
       React.createElement(
         'div',
-        { className: 'grid grid-cols-7 mb-1' },
+        { style: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', marginBottom: '4px' } },
         weekDayHeaders.map((name) =>
           React.createElement(
             'div',
@@ -121,7 +121,7 @@ export function DatePicker({
       // Días
       React.createElement(
         'div',
-        { className: 'grid grid-cols-7' },
+        { style: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)' } },
         days.map((day, i) => {
           const isCurrentMonth = day.getMonth() === viewMonth;
           const isSelected = selectedDate && isSameDay(day, selectedDate);

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,11 @@ export { CreateEventButton } from './components/event/CreateEventButton.js';
 export { CalendarBadge } from './components/event/CalendarBadge.js';
 export { UpcomingEvents } from './components/event/UpcomingEvents.js';
 
+// Pickers (reutilizables por otros plugins)
+export { DatePicker } from './components/internal/DatePicker.js';
+export { TimePicker } from './components/internal/TimePicker.js';
+export { ColorPicker } from './components/internal/ColorPicker.js';
+
 // Utils
 export { CALENDAR_SETTINGS } from './utils/settings.js';
 export { STATUS_LABELS, STATUS_COLORS, formatStatus, toSelectOptions } from './utils/labels.js';


### PR DESCRIPTION
## Summary
- Export `DatePicker`, `TimePicker`, `ColorPicker` as public API components for reuse by other plugins
- Fix `DatePicker` grid layout using inline styles instead of Tailwind classes to prevent rendering issues when used cross-plugin

## Context
The picker components were internal but their prop types were already exported (inconsistency). Other plugins in the vet kit need `DatePicker` for date fields (birth date, follow-up dates). The Tailwind `grid-cols-7` class didn't render when the component was used inside another plugin's context.

## Test plan
- [ ] Verify DatePicker renders correctly in calendar plugin views
- [ ] Verify DatePicker renders correctly when imported from another plugin (e.g., patients)
- [ ] Verify TimePicker and ColorPicker are importable from `@coongro/calendar`

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DatePicker, TimePicker, and ColorPicker components are now available as public exports for use in your projects.

* **Style**
  * DatePicker calendar grid layout styling refined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->