### PR TITLE
chore: Promote develop to staging

### DIFF
--- a/.changeset/export-pickers.md
+++ b/.changeset/export-pickers.md
@@ -1,0 +1,5 @@
+---
+"@coongro/calendar": minor
+---
+
+Export DatePicker, TimePicker, ColorPicker as public API components. Fix DatePicker cross-plugin CSS with inline styles.

--- a/.turbo/turbo-build.log
+++ b/.turbo/turbo-build.log
@@ -1,0 +1,21 @@
+
+> @coongro/calendar@0.1.1 build A:\Coongro2\Coongro\plugins\calendar
+> npm run build:css && npm run copy:fontawesome && tsc
+
+npm warn config ignoring workspace config at A:\Coongro2\Coongro\plugins\calendar/.npmrc
+
+> @coongro/calendar@0.1.1 build:css
+> tailwindcss -c tailwind.config.cjs -i ./src/styles/tailwind.css -o ./dist/assets/tailwind.css --minify
+
+Browserslist: caniuse-lite is outdated. Please run:
+  npx update-browserslist-db@latest
+  Why you should do it regularly: https://github.com/browserslist/update-db#readme
+
+Rebuilding...
+
+Done in 864ms.
+npm warn config ignoring workspace config at A:\Coongro2\Coongro\plugins\calendar/.npmrc
+
+> @coongro/calendar@0.1.1 copy:fontawesome
+> node scripts/copy-fontawesome.cjs
+

--- a/src/components/internal/DatePicker.tsx
+++ b/src/components/internal/DatePicker.tsx
@@ -108,7 +108,7 @@ export function DatePicker({
       // Headers
       React.createElement(
         'div',
-        { className: 'grid grid-cols-7 mb-1' },
+        { style: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', marginBottom: '4px' } },
         weekDayHeaders.map((name) =>
           React.createElement(
             'div',
@@ -121,7 +121,7 @@ export function DatePicker({
       // Días
       React.createElement(
         'div',
-        { className: 'grid grid-cols-7' },
+        { style: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)' } },
         days.map((day, i) => {
           const isCurrentMonth = day.getMonth() === viewMonth;
           const isSelected = selectedDate && isSameDay(day, selectedDate);

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,11 @@ export { CreateEventButton } from './components/event/CreateEventButton.js';
 export { CalendarBadge } from './components/event/CalendarBadge.js';
 export { UpcomingEvents } from './components/event/UpcomingEvents.js';
 
+// Pickers (reutilizables por otros plugins)
+export { DatePicker } from './components/internal/DatePicker.js';
+export { TimePicker } from './components/internal/TimePicker.js';
+export { ColorPicker } from './components/internal/ColorPicker.js';
+
 // Utils
 export { CALENDAR_SETTINGS } from './utils/settings.js';
 export { STATUS_LABELS, STATUS_COLORS, formatStatus, toSelectOptions } from './utils/labels.js';


### PR DESCRIPTION
## Summary
Promote develop to staging for version bump and publish to Verdaccio.

Includes:
- Export DatePicker, TimePicker, ColorPicker as public API
- Fix DatePicker cross-plugin CSS with inline styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)