### PR TITLE
chore: Release v0.2.0 — Export pickers

### DIFF
--- a/.changeset/export-pickers.md
+++ b/.changeset/export-pickers.md
@@ -1,5 +1,0 @@
----
-"@coongro/calendar": minor
----
-
-Export DatePicker, TimePicker, ColorPicker as public API components. Fix DatePicker cross-plugin CSS with inline styles.

--- a/.changeset/export-pickers.md
+++ b/.changeset/export-pickers.md
@@ -1,0 +1,5 @@
+---
+"@coongro/calendar": minor
+---
+
+Export DatePicker, TimePicker, ColorPicker as public API components. Fix DatePicker cross-plugin CSS with inline styles.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,10 @@ jobs:
           echo "@coongro:registry=${{ secrets.STAGING_VERDACCIO_URL }}" > .npmrc
           echo "//${{ secrets.STAGING_VERDACCIO_URL_HOST }}/:_authToken=${{ secrets.STAGING_VERDACCIO_TOKEN }}" >> .npmrc
 
-      - run: npm install
+      - name: Install dependencies
+        run: |
+          rm -f package-lock.json
+          npm install
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,10 @@ jobs:
           echo "@coongro:registry=${{ secrets.STAGING_VERDACCIO_URL }}" > .npmrc
           echo "//${{ secrets.STAGING_VERDACCIO_URL_HOST }}/:_authToken=${{ secrets.STAGING_VERDACCIO_TOKEN }}" >> .npmrc
 
-      - run: npm install
+      - name: Install dependencies
+        run: |
+          rm -f package-lock.json
+          npm install
       - run: npm run build
 
       - name: Publish to production Verdaccio

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,13 @@ jobs:
     name: Version or Publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -41,3 +46,23 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           NAME=$(node -p "require('./package.json').name")
           echo "### Published $NAME@$VERSION to staging" >> $GITHUB_STEP_SUMMARY
+
+      - name: Sync develop with staging
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout develop
+          git merge staging --no-edit || {
+            git merge --abort
+            gh pr create \
+              --base develop \
+              --head staging \
+              --title "sync: merge staging into develop (conflicts)" \
+              --body "Merge automático de staging a develop falló por conflictos. Resolver manualmente."
+            echo "::warning::Conflictos al sincronizar develop. PR creado."
+            exit 0
+          }
+          git push origin develop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,10 @@ jobs:
           echo "@coongro:registry=${{ secrets.STAGING_VERDACCIO_URL }}" > .npmrc
           echo "//${{ secrets.STAGING_VERDACCIO_URL_HOST }}/:_authToken=${{ secrets.STAGING_VERDACCIO_TOKEN }}" >> .npmrc
 
-      - run: npm install
+      - name: Install dependencies
+        run: |
+          rm -f package-lock.json
+          npm install
       - run: npm run build
 
       - name: Create Release PR or Publish

--- a/.turbo/turbo-build.log
+++ b/.turbo/turbo-build.log
@@ -1,0 +1,21 @@
+
+> @coongro/calendar@0.1.1 build A:\Coongro2\Coongro\plugins\calendar
+> npm run build:css && npm run copy:fontawesome && tsc
+
+npm warn config ignoring workspace config at A:\Coongro2\Coongro\plugins\calendar/.npmrc
+
+> @coongro/calendar@0.1.1 build:css
+> tailwindcss -c tailwind.config.cjs -i ./src/styles/tailwind.css -o ./dist/assets/tailwind.css --minify
+
+Browserslist: caniuse-lite is outdated. Please run:
+  npx update-browserslist-db@latest
+  Why you should do it regularly: https://github.com/browserslist/update-db#readme
+
+Rebuilding...
+
+Done in 864ms.
+npm warn config ignoring workspace config at A:\Coongro2\Coongro\plugins\calendar/.npmrc
+
+> @coongro/calendar@0.1.1 copy:fontawesome
+> node scripts/copy-fontawesome.cjs
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @coongro/calendar
 
+## 0.2.0
+
+### Minor Changes
+
+- 357e8f4: Export DatePicker, TimePicker, ColorPicker as public API components. Fix DatePicker cross-plugin CSS with inline styles.
+
 ## 0.1.1
 
 ### Patch Changes

--- a/coongro.manifest.json
+++ b/coongro.manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "calendar",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "apiVersion": "2.0",
   "assets": {
     "styles": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coongro/calendar",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "description": "Plugin de calendario reutilizable: eventos, calendarios, tipos de evento y componentes UI para consumo por otros plugins",
   "main": "dist/index.js",

--- a/src/components/internal/DatePicker.tsx
+++ b/src/components/internal/DatePicker.tsx
@@ -108,7 +108,7 @@ export function DatePicker({
       // Headers
       React.createElement(
         'div',
-        { className: 'grid grid-cols-7 mb-1' },
+        { style: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', marginBottom: '4px' } },
         weekDayHeaders.map((name) =>
           React.createElement(
             'div',
@@ -121,7 +121,7 @@ export function DatePicker({
       // Días
       React.createElement(
         'div',
-        { className: 'grid grid-cols-7' },
+        { style: { display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)' } },
         days.map((day, i) => {
           const isCurrentMonth = day.getMonth() === viewMonth;
           const isSelected = selectedDate && isSameDay(day, selectedDate);

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,11 @@ export { CreateEventButton } from './components/event/CreateEventButton.js';
 export { CalendarBadge } from './components/event/CalendarBadge.js';
 export { UpcomingEvents } from './components/event/UpcomingEvents.js';
 
+// Pickers (reutilizables por otros plugins)
+export { DatePicker } from './components/internal/DatePicker.js';
+export { TimePicker } from './components/internal/TimePicker.js';
+export { ColorPicker } from './components/internal/ColorPicker.js';
+
 // Utils
 export { CALENDAR_SETTINGS } from './utils/settings.js';
 export { STATUS_LABELS, STATUS_COLORS, formatStatus, toSelectOptions } from './utils/labels.js';


### PR DESCRIPTION
## Summary
Release calendar v0.2.0 to production Verdaccio.

- Export DatePicker, TimePicker, ColorPicker as public API
- Fix cross-plugin CSS with inline styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)