### PR TITLE
refactor: migrate EventList to DataTable with mobileRender

### DIFF
--- a/.changeset/swift-events-migrate.md
+++ b/.changeset/swift-events-migrate.md
@@ -1,0 +1,5 @@
+---
+"@coongro/calendar": patch
+---
+
+Migrate EventList from manual UI.Table to DataTable with mobileRender card view

--- a/src/components/event/EventList.tsx
+++ b/src/components/event/EventList.tsx
@@ -2,16 +2,43 @@ import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
 import { useEvents } from '../../hooks/useEvents.js';
 import type { EventListProps } from '../../types/components.js';
+import type { CalendarEvent } from '../../types/event.js';
+import type { SortDirection } from '../../types/filters.js';
 import { formatEventDateTime } from '../../utils/date.js';
 import { formatStatus, STATUS_BADGE_CLASSES } from '../../utils/labels.js';
-import { PinIcon, CalendarIcon } from '../internal/icons.js';
+import { CalendarIcon, PinIcon } from '../internal/icons.js';
 
 const React = getHostReact();
 const UI = getHostUI();
-const { useState, useCallback } = React;
+const { useState, useCallback, useMemo } = React;
+
+const SORTABLE_KEYS = new Set(['title', 'start_at', 'status']);
+
+// Helpers de renderizado reutilizados en columnas desktop y cards móvil
+function renderColorDot(color: string | undefined | null) {
+  if (!color) return null;
+  return React.createElement('span', {
+    className: 'w-2.5 h-2.5 rounded-full shrink-0',
+    style: { backgroundColor: color },
+  });
+}
+
+function renderStatusBadge(
+  status: string,
+  statusConfig?: Record<string, { label: string; color: string }>
+) {
+  const label = statusConfig?.[status]?.label ?? formatStatus(status);
+  return React.createElement(
+    UI.Badge,
+    { variant: 'outline', className: STATUS_BADGE_CLASSES[status] ?? '' },
+    label
+  );
+}
 
 export function EventList({
   filters: initialFilters,
+  columns: customColumns,
+  extraColumns = [],
   extraActions = [],
   statusConfig,
   onRowClick,
@@ -20,12 +47,14 @@ export function EventList({
   emptyStateAction,
   className = '',
 }: EventListProps) {
-  const { data, loading, error, setFilters, pagination, goToPage } = useEvents({
+  const { data, loading, error, setFilters, setSort, pagination, goToPage, refetch } = useEvents({
     ...initialFilters,
     pageSize,
   });
 
   const [searchValue, setSearchValue] = useState('');
+  const [sortKey, setSortKey] = useState<string>('');
+  const [sortDir, setSortDir] = useState<SortDirection>('asc');
 
   const handleSearch = useCallback(
     (value: string) => {
@@ -38,163 +67,135 @@ export function EventList({
     [setFilters, initialFilters]
   );
 
-  const getStatusLabel = (status: string) => statusConfig?.[status]?.label ?? formatStatus(status);
+  const handleSort = useCallback(
+    (key: string, direction: 'asc' | 'desc' | null) => {
+      if (!SORTABLE_KEYS.has(key)) return;
+      setSortKey(direction ? key : '');
+      setSortDir((direction ?? 'asc') as SortDirection);
+      setSort(key, direction ?? 'asc');
+    },
+    [setSort]
+  );
 
-  return React.createElement(
-    'div',
-    { className: `flex flex-col gap-4 ${className}` },
+  const dtColumns = useMemo(() => {
+    const base = customColumns ?? [
+      {
+        key: 'title',
+        header: 'Titulo',
+        sortable: true,
+        render: (evt: CalendarEvent) =>
+          React.createElement(
+            'div',
+            { className: 'flex items-center gap-2' },
+            renderColorDot(evt.color),
+            React.createElement(
+              'div',
+              { className: 'flex flex-col gap-0.5 min-w-0' },
+              React.createElement('span', { className: 'truncate' }, evt.title),
+              evt.location &&
+                React.createElement(
+                  'div',
+                  {
+                    className: 'flex items-center gap-1 text-xs text-cg-text-muted font-normal',
+                  },
+                  React.createElement(PinIcon, null),
+                  React.createElement('span', { className: 'truncate' }, evt.location)
+                )
+            )
+          ),
+      },
+      {
+        key: 'start_at',
+        header: 'Fecha',
+        sortable: true,
+        render: (evt: CalendarEvent) => formatEventDateTime(evt.start_at),
+      },
+      {
+        key: 'status',
+        header: 'Estado',
+        sortable: true,
+        render: (evt: CalendarEvent) => renderStatusBadge(evt.status, statusConfig),
+      },
+    ];
+    return [...base, ...extraColumns];
+  }, [customColumns, extraColumns, statusConfig]);
 
-    // FilterBar
-    React.createElement(UI.FilterBar, {
-      searchValue,
-      onSearchChange: handleSearch,
-      searchPlaceholder: 'Buscar eventos...',
-    }),
+  const dtActions = useMemo(() => {
+    if (extraActions.length === 0) return undefined;
+    return extraActions.map((a) => ({
+      label: a.label,
+      onClick: a.onClick,
+      variant: a.variant as 'ghost' | 'destructive' | undefined,
+    }));
+  }, [extraActions]);
 
-    // Error
-    error &&
+  const mobileRender = useCallback(
+    (evt: CalendarEvent) =>
       React.createElement(
         'div',
-        { className: 'text-sm text-cg-danger p-2 rounded bg-cg-danger-bg' },
-        error
-      ),
-
-    // Table
-    React.createElement(
-      UI.Table,
-      null,
-      React.createElement(
-        UI.TableHeader,
-        null,
+        { className: 'flex flex-col gap-1' },
         React.createElement(
-          UI.TableRow,
-          null,
-          React.createElement(UI.TableHead, null, 'Título'),
-          React.createElement(UI.TableHead, null, 'Fecha'),
-          React.createElement(UI.TableHead, null, 'Estado'),
-          extraActions.length > 0 && React.createElement(UI.TableHead, { className: 'w-10' })
+          'div',
+          { className: 'flex items-center gap-2' },
+          renderColorDot(evt.color),
+          React.createElement('span', { className: 'font-medium text-sm truncate' }, evt.title)
+        ),
+        React.createElement(
+          'div',
+          { className: 'text-xs', style: { color: 'var(--cg-text-muted)' } },
+          formatEventDateTime(evt.start_at)
+        ),
+        evt.location &&
+          React.createElement(
+            'div',
+            {
+              className: 'flex items-center gap-1 text-xs',
+              style: { color: 'var(--cg-text-muted)' },
+            },
+            React.createElement(PinIcon, null),
+            React.createElement('span', { className: 'truncate' }, evt.location)
+          ),
+        React.createElement(
+          'div',
+          { className: 'mt-1' },
+          renderStatusBadge(evt.status, statusConfig)
         )
       ),
-      React.createElement(
-        UI.TableBody,
-        null,
-        loading
-          ? Array.from({ length: 5 }).map((_, i) =>
-              React.createElement(
-                UI.TableRow,
-                { key: `skeleton-${i}` },
-                React.createElement(
-                  UI.TableCell,
-                  null,
-                  React.createElement(UI.Skeleton, { className: 'h-4 w-32' })
-                ),
-                React.createElement(
-                  UI.TableCell,
-                  null,
-                  React.createElement(UI.Skeleton, { className: 'h-4 w-24' })
-                ),
-                React.createElement(
-                  UI.TableCell,
-                  null,
-                  React.createElement(UI.Skeleton, { className: 'h-4 w-16' })
-                )
-              )
-            )
-          : data.length === 0
-            ? React.createElement(
-                UI.TableRow,
-                null,
-                React.createElement(
-                  UI.TableCell,
-                  { colSpan: 4 },
-                  React.createElement(UI.EmptyState, {
-                    title: emptyMessage,
-                    icon: React.createElement(CalendarIcon, null),
-                    action: emptyStateAction,
-                  })
-                )
-              )
-            : data.map((evt) =>
-                React.createElement(
-                  UI.TableRow,
-                  {
-                    key: evt.id,
-                    className: onRowClick ? 'cursor-pointer' : '',
-                    onClick: onRowClick ? () => onRowClick(evt) : undefined,
-                  },
-                  React.createElement(
-                    UI.TableCell,
-                    { className: 'font-medium' },
-                    React.createElement(
-                      'div',
-                      { className: 'flex items-center gap-2' },
-                      evt.color &&
-                        React.createElement('span', {
-                          className: 'w-2.5 h-2.5 rounded-full shrink-0',
-                          style: { backgroundColor: evt.color },
-                        }),
-                      React.createElement(
-                        'div',
-                        { className: 'flex flex-col gap-0.5 min-w-0' },
-                        React.createElement('span', { className: 'truncate' }, evt.title),
-                        evt.location &&
-                          React.createElement(
-                            'div',
-                            {
-                              className:
-                                'flex items-center gap-1 text-xs text-cg-text-muted font-normal',
-                            },
-                            React.createElement(PinIcon, null),
-                            React.createElement('span', { className: 'truncate' }, evt.location)
-                          )
-                      )
-                    )
-                  ),
-                  React.createElement(UI.TableCell, null, formatEventDateTime(evt.start_at)),
-                  React.createElement(
-                    UI.TableCell,
-                    null,
-                    React.createElement(
-                      UI.Badge,
-                      { variant: 'outline', className: STATUS_BADGE_CLASSES[evt.status] ?? '' },
-                      getStatusLabel(evt.status)
-                    )
-                  ),
-                  extraActions.length > 0 &&
-                    React.createElement(
-                      UI.TableCell,
-                      null,
-                      extraActions.map((action) =>
-                        React.createElement(
-                          UI.Button,
-                          {
-                            key: action.key,
-                            variant: action.variant ?? 'ghost',
-                            size: 'sm',
-                            onClick: (e: { stopPropagation: () => void }) => {
-                              e.stopPropagation();
-                              action.onClick(evt);
-                            },
-                          },
-                          action.icon ?? action.label
-                        )
-                      )
-                    )
-                )
-              )
-      )
-    ),
-
-    // Paginación
-    pagination.totalPages > 1 &&
-      React.createElement(
-        'div',
-        { className: 'flex justify-center' },
-        React.createElement(UI.Pagination, {
-          currentPage: pagination.page,
-          totalPages: pagination.totalPages,
-          onPageChange: goToPage,
-        })
-      )
+    [statusConfig]
   );
+
+  return React.createElement(UI.DataTable, {
+    data,
+    rowKey: (evt: CalendarEvent) => evt.id,
+    loading,
+    error: error ?? undefined,
+    onRetry: refetch,
+    columns: dtColumns,
+    searchPlaceholder: 'Buscar eventos...',
+    searchValue,
+    onSearchChange: handleSearch,
+    sortKey: sortKey || null,
+    sortDirection: sortDir as 'asc' | 'desc' | null,
+    onSortChange: handleSort,
+    pagination: {
+      page: pagination.page,
+      pageSize: pagination.pageSize,
+      total: pagination.total,
+    },
+    onPageChange: goToPage,
+    actions: dtActions,
+    onRowClick,
+    emptyState: {
+      title: emptyStateAction ? 'No hay eventos aun' : emptyMessage,
+      description: emptyStateAction
+        ? 'Crea tu primer evento para empezar a organizar tu agenda.'
+        : undefined,
+      icon: emptyStateAction ? React.createElement(CalendarIcon, null) : undefined,
+      action: emptyStateAction,
+      filteredTitle: emptyMessage,
+      filteredDescription: 'Prueba con otros terminos o ajusta los filtros.',
+    },
+    mobileRender,
+    className,
+  });
 }


### PR DESCRIPTION
## Summary
- Migra `EventList` de tabla manual (`UI.Table` + skeleton + empty state + paginación) a `UI.DataTable`
- Agrega `mobileRender` con card view mostrando título, fecha, ubicación y estado
- Soporta `columns`, `extraColumns`, sorting, búsqueda y todas las props existentes

## Test plan
- [ ] Verificar EventList en desktop: columnas, sorting, búsqueda, paginación
- [ ] Verificar EventList en móvil (<640px): cards con título, fecha, ubicación, estado
- [ ] Verificar empty state sin datos y con filtros activos
- [ ] Verificar `extraActions` funcionan correctamente
- [ ] Verificar `onRowClick` en ambas vistas

Closes COONG-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * EventList now supports sortable columns for event title, start date, and status.
  * Mobile view displays events in an improved card-based layout.

* **Improvements**
  * EventList component now accepts custom column configurations for enhanced flexibility and data presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->