### PR TITLE
feat: migrate to strict @coongro/datetime API and Drizzle Date mode

### DIFF
--- a/.changeset/datetime-migration.md
+++ b/.changeset/datetime-migration.md
@@ -1,0 +1,14 @@
+---
+"@coongro/calendar": minor
+---
+
+Migrate to strict `@coongro/datetime` API and Drizzle `mode: 'date'`.
+
+- Entities (`CalendarEvent`, form data): use branded `UTCTimestamp` for timestamp fields.
+- Repositories: schema columns switched to `mode: 'date'`, mappers apply `toUTCTimestamp()` so JSON payloads are ISO-Z.
+- `useDateNavigation` returns `Date` ranges (direct use in Drizzle filters).
+- `utils/date.ts` wrappers require `tz` (no more fallback to browser timezone); components call `useTenantTimezone()` and pass it through.
+- New `useTenantTimezone()` hook reads `workspace.timezone` setting with browser fallback.
+- Schema: all timestamps are `timestamp with time zone` (migration `0001_lean_white_tiger`).
+
+Fixes timezone bug where events created at 22:30 ART rendered as next-day 01:30 UTC.

--- a/drizzle/0001_lean_white_tiger.sql
+++ b/drizzle/0001_lean_white_tiger.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "module_calendar_calendars" ALTER COLUMN "deleted_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_calendars" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_calendars" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_event_types" ALTER COLUMN "deleted_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_event_types" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_event_types" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_events" ALTER COLUMN "start_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_events" ALTER COLUMN "end_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_events" ALTER COLUMN "recurrence_end" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_events" ALTER COLUMN "deleted_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_events" ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "module_calendar_events" ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,322 @@
+{
+  "id": "a954e565-5d92-49fb-bbaa-027cf0d341e0",
+  "prevId": "59ef7b79-0beb-468e-879f-876ead5ffcf0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.module_calendar_calendars": {
+      "name": "module_calendar_calendars",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_visible": {
+          "name": "is_visible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_calendar_event_types": {
+      "name": "module_calendar_event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_duration": {
+          "name": "default_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_calendar_events": {
+      "name": "module_calendar_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_at": {
+          "name": "start_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_at": {
+          "name": "end_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "all_day": {
+          "name": "all_day",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type_id": {
+          "name": "event_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_end": {
+          "name": "recurrence_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_parent_id": {
+          "name": "recurrence_parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminders": {
+          "name": "reminders",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1773565081295,
       "tag": "0000_typical_nekra",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1776493031360,
+      "tag": "0001_lean_white_tiger",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -58,10 +58,12 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
+    "@coongro/datetime": ">=0.24.0",
     "@coongro/plugin-sdk": ">=0.1.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",
+    "@coongro/datetime": ">=0.24.0",
     "@coongro/plugin-sdk": ">=0.14.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/src/components/calendar/AgendaList.tsx
+++ b/src/components/calendar/AgendaList.tsx
@@ -1,6 +1,7 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
 import { useIsMobile } from '../../hooks/useIsMobile.js';
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { TOKENS, statusBadgeStyle } from '../../styles/tokens.js';
 import type { AgendaListProps } from '../../types/components.js';
 import type { CalendarEvent } from '../../types/event.js';
@@ -9,7 +10,7 @@ import {
   toDateString,
   getDayName,
   getMonthName,
-  isSameDay,
+  toDateKey,
 } from '../../utils/date.js';
 import { formatStatus } from '../../utils/labels.js';
 import { PinIcon, CalendarIcon } from '../internal/icons.js';
@@ -26,6 +27,7 @@ export function AgendaList({
   className = '',
 }: AgendaListProps) {
   const isMobile = useIsMobile();
+  const tz = useTenantTimezone();
   const grouped = useMemo(() => {
     const map: Record<string, CalendarEvent[]> = {};
     const sortedEvents = [...events].sort(
@@ -47,7 +49,7 @@ export function AgendaList({
     });
   }
 
-  const today = new Date();
+  const todayKey = toDateKey(new Date(), tz);
 
   return React.createElement(
     'div',
@@ -62,7 +64,7 @@ export function AgendaList({
     },
     grouped.map(([dateStr, dayEvents]) => {
       const date = new Date(`${dateStr}T00:00:00`);
-      const isToday = isSameDay(date, today);
+      const isToday = dateStr === todayKey;
       const dayName = getDayName(date).substring(0, 3).toUpperCase();
       const dayNum = date.getDate();
       const monthYear = `${getMonthName(date.getMonth())} ${date.getFullYear()}`;
@@ -263,7 +265,7 @@ export function AgendaList({
                       },
                       evt.all_day
                         ? 'Todo el día'
-                        : `${formatEventTime(evt.start_at)} - ${formatEventTime(evt.end_at)}`
+                        : `${formatEventTime(evt.start_at, tz)} - ${formatEventTime(evt.end_at, tz)}`
                     ),
 
                   // Título + hora (mobile) / ubicación
@@ -301,9 +303,9 @@ export function AgendaList({
                         evt.all_day
                           ? 'Todo el día'
                           : [
-                              formatEventTime(evt.start_at),
+                              formatEventTime(evt.start_at, tz),
                               ' — ',
-                              formatEventTime(evt.end_at),
+                              formatEventTime(evt.end_at, tz),
                               evt.location ? ' · ' + evt.location : '',
                             ].join('')
                       ),

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -1,9 +1,11 @@
+import { localToUTC } from '@coongro/datetime';
 import { getHostReact, getHostUI, useViewContributions } from '@coongro/plugin-sdk';
 
 import { useCalendarSettings } from '../../hooks/useCalendarSettings.js';
 import { useDateNavigation } from '../../hooks/useDateNavigation.js';
 import { useEvents } from '../../hooks/useEvents.js';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { TOKENS } from '../../styles/tokens.js';
 import type { CalendarViewProps, CalendarViewMode } from '../../types/components.js';
 import { toDateString } from '../../utils/date.js';
@@ -51,6 +53,7 @@ export function CalendarView({
 }: CalendarViewProps) {
   const { settings } = useCalendarSettings();
   const isMobile = useIsMobile();
+  const tz = useTenantTimezone();
   const nav = useDateNavigation(defaultView ?? settings.defaultView);
 
   const { data: internalEvents, loading: internalLoading } = useEvents({
@@ -66,8 +69,8 @@ export function CalendarView({
     const external = externalEvents ?? [];
     // Internos ya vienen filtrados por useEvents (from/to). Solo filtrar externos.
     if (external.length === 0) return internal;
-    const start = new Date(nav.rangeStart).getTime();
-    const end = new Date(nav.rangeEnd).getTime();
+    const start = nav.rangeStart.getTime();
+    const end = nav.rangeEnd.getTime();
     const filteredExternal = external.filter((e) => {
       const t = new Date(e.start_at).getTime();
       return t >= start && t <= end;
@@ -81,10 +84,10 @@ export function CalendarView({
   const prevRange = useRef<string>('');
   useEffect(() => {
     if (!onDateRangeChange) return;
-    const rangeKey = `${nav.rangeStart}|${nav.rangeEnd}`;
+    const rangeKey = `${nav.rangeStart.toISOString()}|${nav.rangeEnd.toISOString()}`;
     if (rangeKey !== prevRange.current) {
       prevRange.current = rangeKey;
-      onDateRangeChange(nav.rangeStart, nav.rangeEnd);
+      onDateRangeChange(nav.rangeStart.toISOString(), nav.rangeEnd.toISOString());
     }
   }, [nav.rangeStart, nav.rangeEnd, onDateRangeChange]);
 
@@ -425,7 +428,7 @@ export function CalendarView({
         });
       case 'three-day':
         return React.createElement(ThreeDayGrid, {
-          startDate: nav.rangeStart,
+          startDate: nav.rangeStart.toISOString(),
           events,
           startHour: settings.startHour,
           endHour: settings.endHour,
@@ -434,12 +437,12 @@ export function CalendarView({
           onEventClick,
           onSlotClick: onSlotClick
             ? (date, hour) =>
-                onSlotClick(`${date}T${String(Math.floor(hour)).padStart(2, '0')}:00:00.000Z`)
+                onSlotClick(localToUTC(date, `${String(Math.floor(hour)).padStart(2, '0')}:00`, tz))
             : undefined,
         });
       case 'week':
         return React.createElement(WeekGrid, {
-          startDate: nav.rangeStart,
+          startDate: nav.rangeStart.toISOString(),
           events,
           startHour: settings.startHour,
           endHour: settings.endHour,
@@ -448,13 +451,13 @@ export function CalendarView({
           onEventClick,
           onSlotClick: onSlotClick
             ? (date, hour) =>
-                onSlotClick(`${date}T${String(Math.floor(hour)).padStart(2, '0')}:00:00.000Z`)
+                onSlotClick(localToUTC(date, `${String(Math.floor(hour)).padStart(2, '0')}:00`, tz))
             : undefined,
           showWeekends: settings.showWeekends,
         });
       case 'day':
         return React.createElement(DayColumn, {
-          date: nav.rangeStart,
+          date: nav.rangeStart.toISOString(),
           events,
           startHour: settings.startHour,
           endHour: settings.endHour,
@@ -464,8 +467,10 @@ export function CalendarView({
           onEventClick,
           onSlotClick: onSlotClick
             ? (hour) => {
-                const dateStr = nav.rangeStart.substring(0, 10);
-                onSlotClick(`${dateStr}T${String(Math.floor(hour)).padStart(2, '0')}:00:00.000Z`);
+                const dateStr = nav.rangeStart.toISOString().substring(0, 10);
+                onSlotClick(
+                  localToUTC(dateStr, `${String(Math.floor(hour)).padStart(2, '0')}:00`, tz)
+                );
               }
             : undefined,
         });

--- a/src/components/calendar/MonthGrid.tsx
+++ b/src/components/calendar/MonthGrid.tsx
@@ -1,9 +1,10 @@
 import { getHostReact } from '@coongro/plugin-sdk';
 
 import { useIsMobile } from '../../hooks/useIsMobile.js';
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { TOKENS } from '../../styles/tokens.js';
 import type { MonthGridProps } from '../../types/components.js';
-import { getMonthGridDays, getShortDayName, toDateString, isSameDay } from '../../utils/date.js';
+import { getMonthGridDays, getShortDayName, toDateString, toDateKey } from '../../utils/date.js';
 import { groupEventsByDay } from '../../utils/grid-helpers.js';
 import { EventCard } from '../event/EventCard.js';
 
@@ -80,6 +81,8 @@ export function MonthGrid({
   className = '',
 }: MonthGridProps) {
   const isMobile = useIsMobile();
+  const tz = useTenantTimezone();
+  const todayKey = toDateKey(new Date(), tz);
   const days = useMemo(() => getMonthGridDays(year, month), [year, month]);
 
   const eventsByDate = useMemo(() => groupEventsByDay(events), [events]);
@@ -150,7 +153,7 @@ export function MonthGrid({
       filteredDays.map((day, i) => {
         const dateStr = toDateString(day);
         const isCurrentMonth = day.getMonth() === month;
-        const isToday = isSameDay(day, new Date());
+        const isToday = dateStr === todayKey;
         const dayEvents = eventsByDate[dateStr] ?? [];
 
         const isWeekend = day.getDay() === 0 || day.getDay() === 6;

--- a/src/components/calendar/ThreeDayGrid.tsx
+++ b/src/components/calendar/ThreeDayGrid.tsx
@@ -5,9 +5,10 @@
  */
 import { getHostReact } from '@coongro/plugin-sdk';
 
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { TOKENS } from '../../styles/tokens.js';
 import type { WeekGridProps } from '../../types/components.js';
-import { getShortDayName, generateTimeSlots, toDateString, isSameDay } from '../../utils/date.js';
+import { getShortDayName, generateTimeSlots, toDateString, toDateKey } from '../../utils/date.js';
 import { SLOT_HEIGHT_3DAY, GUTTER_WIDTH_3DAY, EVENT_Z } from '../../utils/grid-constants.js';
 import {
   computeNowPosition,
@@ -36,6 +37,7 @@ export function ThreeDayGrid({
   onEventClick,
   onSlotClick,
 }: WeekGridProps) {
+  const tz = useTenantTimezone();
   const slotHeight = SLOT_HEIGHT_3DAY;
 
   // 3 dias consecutivos desde startDate
@@ -57,6 +59,7 @@ export function ThreeDayGrid({
 
   const slotsPerHour = Math.round(60 / slotDuration);
   const now = new Date();
+  const todayKey = toDateKey(now, tz);
 
   const { nowHour, nowTimeStr, gridStartMin, gridEndMin, nowInRange, nowTop } = computeNowPosition(
     startHour,
@@ -91,7 +94,7 @@ export function ThreeDayGrid({
         style: { width: `${GUTTER_W}px`, flexShrink: 0, borderRight: `1px solid ${TOKENS.border}` },
       }),
       ...days.map((day, i) => {
-        const isToday = isSameDay(day, now);
+        const isToday = toDateString(day) === todayKey;
         const isWeekend = day.getDay() === 0 || day.getDay() === 6;
 
         return React.createElement(
@@ -195,7 +198,7 @@ export function ThreeDayGrid({
           { style: { display: 'flex', flex: '1' } },
           ...days.map((day, dayIdx) => {
             const dateStr = toDateString(day);
-            const isToday = isSameDay(day, now);
+            const isToday = toDateString(day) === todayKey;
             const isWeekend = day.getDay() === 0 || day.getDay() === 6;
             const dayEvents = eventsByDay[dateStr] ?? [];
             const colBg = dayColumnBackground(isToday, isWeekend);

--- a/src/components/calendar/WeekGrid.tsx
+++ b/src/components/calendar/WeekGrid.tsx
@@ -1,6 +1,7 @@
 import { getHostReact } from '@coongro/plugin-sdk';
 
 import { useIsMobile } from '../../hooks/useIsMobile.js';
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { TOKENS } from '../../styles/tokens.js';
 import type { WeekGridProps } from '../../types/components.js';
 import {
@@ -8,7 +9,7 @@ import {
   getShortDayName,
   generateTimeSlots,
   toDateString,
-  isSameDay,
+  toDateKey,
 } from '../../utils/date.js';
 import {
   SLOT_HEIGHT_DESKTOP,
@@ -44,6 +45,7 @@ export function WeekGrid({
   showWeekends = true,
 }: WeekGridProps) {
   const isMobile = useIsMobile();
+  const tz = useTenantTimezone();
   const slotHeight = isMobile ? SLOT_HEIGHT_MOBILE : SLOT_HEIGHT_DESKTOP;
   const gutterWidth = isMobile ? GUTTER_WIDTH_MOBILE : GUTTER_WIDTH_DESKTOP;
 
@@ -62,6 +64,7 @@ export function WeekGrid({
 
   const slotsPerHour = Math.round(60 / slotDuration);
   const now = new Date();
+  const todayKey = toDateKey(now, tz);
 
   const { nowHour, nowTimeStr, gridStartMin, gridEndMin, nowInRange, nowTop } = computeNowPosition(
     startHour,
@@ -104,7 +107,7 @@ export function WeekGrid({
 
       // Headers de días
       ...weekDays.map((day) => {
-        const isToday = isSameDay(day, now);
+        const isToday = toDateString(day) === todayKey;
         const isWeekend = day.getDay() === 0 || day.getDay() === 6;
         const dayName = isMobile ? getShortDayName(day).charAt(0) : getShortDayName(day);
 
@@ -198,7 +201,7 @@ export function WeekGrid({
           { style: { display: 'flex', flex: '1' } },
           ...weekDays.map((day) => {
             const dateStr = toDateString(day);
-            const isToday = isSameDay(day, now);
+            const isToday = toDateString(day) === todayKey;
             const isWeekend = day.getDay() === 0 || day.getDay() === 6;
             const dayEvents = eventsByDay[dateStr] ?? [];
 

--- a/src/components/event/EventCard.tsx
+++ b/src/components/event/EventCard.tsx
@@ -1,5 +1,6 @@
 import { getHostReact } from '@coongro/plugin-sdk';
 
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { TOKENS, TRUNCATE, EVENT_CARD_VARIANTS, statusBadgeStyle } from '../../styles/tokens.js';
 import type { EventCardProps } from '../../types/components.js';
 import { formatEventDate, formatEventTime } from '../../utils/date.js';
@@ -53,6 +54,7 @@ export function EventCard({
   onClick,
   className = '',
 }: EventCardProps) {
+  const tz = useTenantTimezone();
   if (render) {
     return render(event) as ReturnType<typeof React.createElement>;
   }
@@ -134,14 +136,14 @@ export function EventCard({
           React.createElement(
             'div',
             { style: { fontSize: cfg.subSize, color: TOKENS.ink3, marginTop: '1px' } },
-            formatEventDate(event.start_at)
+            formatEventDate(event.start_at, tz)
           ),
         showTime &&
           !event.all_day &&
           React.createElement(
             'div',
             { style: { fontSize: cfg.subSize, color: TOKENS.ink3, marginTop: '1px' } },
-            `${formatEventTime(event.start_at)} - ${formatEventTime(event.end_at)}`
+            `${formatEventTime(event.start_at, tz)} - ${formatEventTime(event.end_at, tz)}`
           ),
         showLocation &&
           event.location &&
@@ -196,7 +198,7 @@ export function EventCard({
           {
             style: { fontSize: cfg.timeSize, fontWeight: 600, color: TOKENS.ink3 },
           },
-          formatEventTime(event.start_at)
+          formatEventTime(event.start_at, tz)
         ),
       React.createElement(
         'span',
@@ -265,7 +267,7 @@ export function EventCard({
                 flex: 1,
               },
             },
-            `${formatEventTime(event.start_at)} – ${formatEventTime(event.end_at)}`
+            `${formatEventTime(event.start_at, tz)} – ${formatEventTime(event.end_at, tz)}`
           )
         : React.createElement('span', { style: { flex: 1 } }),
       showStatus && renderStatusBadge(event.status),
@@ -312,7 +314,7 @@ export function EventCard({
           {
             style: { fontSize: cfg.subSize, color: TOKENS.ink3, marginTop: '2px' },
           },
-          formatEventDate(event.start_at)
+          formatEventDate(event.start_at, tz)
         ),
       subtitle
     )

--- a/src/components/event/EventDetail.tsx
+++ b/src/components/event/EventDetail.tsx
@@ -2,6 +2,7 @@ import { getHostReact, getHostUI, useViewContributions } from '@coongro/plugin-s
 
 import { useEvent } from '../../hooks/useEvent.js';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { TOKENS, statusBadgeStyle } from '../../styles/tokens.js';
 import type { EventDetailProps } from '../../types/components.js';
 import { formatEventDateTime } from '../../utils/date.js';
@@ -21,6 +22,7 @@ export function EventDetail({
   className = '',
 }: EventDetailProps) {
   const isMobile = useIsMobile();
+  const tz = useTenantTimezone();
   const { event, loading, error } = useEvent(eventId);
 
   const { sections: entityInfoSections } = useViewContributions(
@@ -166,8 +168,8 @@ export function EventDetail({
           gap: '0.75rem',
         },
       },
-      detail('Inicio', formatEventDateTime(event.start_at)),
-      detail('Fin', formatEventDateTime(event.end_at)),
+      detail('Inicio', formatEventDateTime(event.start_at, tz)),
+      detail('Fin', formatEventDateTime(event.end_at, tz)),
       event.all_day && detail('Tipo', 'Todo el día'),
       event.location
         ? React.createElement(

--- a/src/components/event/EventForm.tsx
+++ b/src/components/event/EventForm.tsx
@@ -1,3 +1,10 @@
+import {
+  formatLocalTime,
+  localToUTC,
+  nowUTC,
+  toDateKey,
+  type UTCTimestamp,
+} from '@coongro/datetime';
 import { getHostReact, getHostUI, useViewContributions } from '@coongro/plugin-sdk';
 
 import { useCalendars } from '../../hooks/useCalendars.js';
@@ -6,9 +13,10 @@ import { useEvent } from '../../hooks/useEvent.js';
 import { useEventMutations } from '../../hooks/useEventMutations.js';
 import { useEventTypes } from '../../hooks/useEventTypes.js';
 import { useIsMobile } from '../../hooks/useIsMobile.js';
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import type { EventFormProps } from '../../types/components.js';
 import type { EventCreateData } from '../../types/event.js';
-import { addMinutes, toDateString } from '../../utils/date.js';
+import { addMinutes } from '../../utils/date.js';
 import { STATUS_LABELS, toSelectOptions } from '../../utils/labels.js';
 import { ColorPicker } from '../internal/ColorPicker.js';
 import { DatePicker } from '../internal/DatePicker.js';
@@ -45,6 +53,7 @@ export function EventForm({
   className = '',
 }: EventFormProps) {
   const isMobile = useIsMobile();
+  const tz = useTenantTimezone();
   const isEdit = !!eventId;
   const { event, loading: loadingEvent } = useEvent(eventId);
   const { settings } = useCalendarSettings();
@@ -63,8 +72,7 @@ export function EventForm({
 
   const isSaving = creating || updating;
 
-  const now = new Date();
-  const defaultStart = now.toISOString();
+  const defaultStart = nowUTC();
   const defaultEnd = addMinutes(defaultStart, settings.defaultDuration);
 
   const [formData, setFormData] = useState<Record<string, unknown>>({
@@ -129,22 +137,11 @@ export function EventForm({
     );
   }
 
-  // Extraer fecha y hora del ISO string usando tiempo local (no UTC)
-  const startDate = formData.start_at ? toDateString(new Date(formData.start_at as string)) : '';
-  const startTime = (formData.start_at as string)
-    ? new Date(formData.start_at as string).toLocaleTimeString('es', {
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false,
-      })
-    : '';
-  const endTime = (formData.end_at as string)
-    ? new Date(formData.end_at as string).toLocaleTimeString('es', {
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: false,
-      })
-    : '';
+  const startAt = formData.start_at as UTCTimestamp | undefined;
+  const endAt = formData.end_at as UTCTimestamp | undefined;
+  const startDate = startAt ? toDateKey(startAt, tz) : '';
+  const startTime = startAt ? formatLocalTime(startAt, tz) : '';
+  const endTime = endAt ? formatLocalTime(endAt, tz) : '';
 
   return React.createElement(
     'form',
@@ -197,7 +194,7 @@ export function EventForm({
         React.createElement(DatePicker, {
           value: startDate,
           onChange: (date: string) => {
-            const st = new Date(`${date}T${startTime || '09:00'}:00`).toISOString();
+            const st = localToUTC(date, startTime || '09:00', tz);
             handleChange('start_at', st);
             handleChange('end_at', addMinutes(st, settings.defaultDuration));
           },
@@ -214,7 +211,7 @@ export function EventForm({
             minuteStep: settings.minuteStep,
             use24Hour: settings.use24Hour,
             onChange: (time: string) => {
-              const st = new Date(`${startDate}T${time}:00`).toISOString();
+              const st = localToUTC(startDate, time, tz);
               handleChange('start_at', st);
               handleChange('end_at', addMinutes(st, settings.defaultDuration));
             },
@@ -231,7 +228,7 @@ export function EventForm({
             minuteStep: settings.minuteStep,
             use24Hour: settings.use24Hour,
             onChange: (time: string) => {
-              handleChange('end_at', new Date(`${startDate}T${time}:00`).toISOString());
+              handleChange('end_at', localToUTC(startDate, time, tz));
             },
           })
         )

--- a/src/components/event/EventList.tsx
+++ b/src/components/event/EventList.tsx
@@ -1,6 +1,7 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
 import { useEvents } from '../../hooks/useEvents.js';
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { TOKENS, TRUNCATE, statusBadgeStyle } from '../../styles/tokens.js';
 import type { EventListProps } from '../../types/components.js';
 import type { CalendarEvent } from '../../types/event.js';
@@ -49,6 +50,7 @@ export function EventList({
   emptyStateAction,
   className = '',
 }: EventListProps) {
+  const tz = useTenantTimezone();
   const { data, loading, error, setFilters, setSort, pagination, goToPage, refetch } = useEvents({
     ...initialFilters,
     pageSize,
@@ -124,7 +126,7 @@ export function EventList({
         key: 'start_at',
         header: 'Fecha',
         sortable: true,
-        render: (evt: CalendarEvent) => formatEventDateTime(evt.start_at),
+        render: (evt: CalendarEvent) => formatEventDateTime(evt.start_at, tz),
       },
       {
         key: 'status',
@@ -169,7 +171,7 @@ export function EventList({
         React.createElement(
           'div',
           { style: { fontSize: '0.75rem', color: TOKENS.ink4 } },
-          formatEventDateTime(evt.start_at)
+          formatEventDateTime(evt.start_at, tz)
         ),
         evt.location &&
           React.createElement(

--- a/src/components/event/EventPicker.tsx
+++ b/src/components/event/EventPicker.tsx
@@ -2,6 +2,7 @@ import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
 import { useEvent } from '../../hooks/useEvent.js';
 import { useEvents } from '../../hooks/useEvents.js';
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import type { EventPickerProps } from '../../types/components.js';
 import type { CalendarEvent } from '../../types/event.js';
 import { formatEventDateTime } from '../../utils/date.js';
@@ -17,6 +18,7 @@ function EventSearchContent({
   filters: EventPickerProps['filters'];
   onResults: (events: CalendarEvent[]) => void;
 }) {
+  const tz = useTenantTimezone();
   const { debouncedSearch, setLoading } = UI.useComboboxContext();
   const { data, loading, search: doSearch } = useEvents({ ...filters, pageSize: 10 });
 
@@ -43,7 +45,7 @@ function EventSearchContent({
             {
               key: evt.id,
               value: evt.id,
-              subtitle: formatEventDateTime(evt.start_at),
+              subtitle: formatEventDateTime(evt.start_at, tz),
             },
             evt.title
           )

--- a/src/components/event/UpcomingEvents.tsx
+++ b/src/components/event/UpcomingEvents.tsx
@@ -1,5 +1,6 @@
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { useUpcomingEvents } from '../../hooks/useUpcomingEvents.js';
 import { TOKENS, TRUNCATE, statusBadgeStyle } from '../../styles/tokens.js';
 import type { UpcomingEventsProps } from '../../types/components.js';
@@ -20,6 +21,7 @@ export function UpcomingEvents({
   emptyMessage = 'No hay próximos eventos',
   className = '',
 }: UpcomingEventsProps) {
+  const tz = useTenantTimezone();
   const { data, loading } = useUpcomingEvents({ limit, calendarIds });
 
   if (loading) {
@@ -97,8 +99,8 @@ export function UpcomingEvents({
               style: { fontSize: '11px', color: TOKENS.ink3, marginTop: '1px' },
             },
             evt.all_day
-              ? formatEventDate(evt.start_at)
-              : `${formatEventDate(evt.start_at)} · ${formatEventTime(evt.start_at)}`
+              ? formatEventDate(evt.start_at, tz)
+              : `${formatEventDate(evt.start_at, tz)} · ${formatEventTime(evt.start_at, tz)}`
           )
         ),
         // Status badge con dot (patron Coongro, no UI.Badge)

--- a/src/components/internal/CalendarGrid.tsx
+++ b/src/components/internal/CalendarGrid.tsx
@@ -4,8 +4,9 @@
  */
 import { getHostReact, getHostUI } from '@coongro/plugin-sdk';
 
+import { useTenantTimezone } from '../../hooks/useTenantTimezone.js';
 import { TOKENS } from '../../styles/tokens.js';
-import { getMonthGridDays, getMonthName, toDateString, isSameDay } from '../../utils/date.js';
+import { getMonthGridDays, getMonthName, toDateString, toDateKey } from '../../utils/date.js';
 
 const React = getHostReact();
 const UI = getHostUI();
@@ -69,6 +70,9 @@ export function CalendarGrid({
   onDayClick,
   daySize = 'sm',
 }: CalendarGridProps) {
+  const tz = useTenantTimezone();
+  const selectedKey = selectedDate ?? null;
+  const todayKey = toDateKey(new Date(), tz);
   const selected = selectedDate ? new Date(`${selectedDate}T00:00:00`) : null;
   const [viewYear, setViewYear] = useState(
     () => selected?.getFullYear() ?? new Date().getFullYear()
@@ -238,8 +242,8 @@ export function CalendarGrid({
           days.map((day, i) => {
             const dateStr = toDateString(day);
             const isCurrentMonth = day.getMonth() === viewMonth;
-            const isSelected = selected && isSameDay(day, selected);
-            const isToday = isSameDay(day, new Date());
+            const isSelected = selectedKey !== null && dateStr === selectedKey;
+            const isToday = dateStr === todayKey;
             const disabled = isDateDisabled(day);
             const dotCount = eventDots[dateStr] ?? 0;
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -22,3 +22,4 @@ export { useEventsByEntity } from './useEventsByEntity.js';
 export type { UseEventsByEntityResult } from './useEventsByEntity.js';
 export { useDateNavigation } from './useDateNavigation.js';
 export type { UseDateNavigationResult } from './useDateNavigation.js';
+export { useTenantTimezone } from './useTenantTimezone.js';

--- a/src/hooks/useDateNavigation.ts
+++ b/src/hooks/useDateNavigation.ts
@@ -1,3 +1,4 @@
+import { addDays, getDayRange } from '@coongro/datetime';
 import { getHostReact } from '@coongro/plugin-sdk';
 
 import type { CalendarViewMode } from '../types/components.js';
@@ -10,6 +11,8 @@ import {
   getMonthName,
 } from '../utils/date.js';
 
+import { useTenantTimezone } from './useTenantTimezone.js';
+
 const React = getHostReact();
 const { useState, useCallback, useMemo } = React;
 
@@ -21,12 +24,13 @@ export interface UseDateNavigationResult {
   goNext: () => void;
   goPrev: () => void;
   goToDate: (date: Date) => void;
-  rangeStart: string;
-  rangeEnd: string;
+  rangeStart: Date;
+  rangeEnd: Date;
   title: string;
 }
 
 export function useDateNavigation(initialView: CalendarViewMode = 'week'): UseDateNavigationResult {
+  const tz = useTenantTimezone();
   const [currentDate, setCurrentDate] = useState(new Date());
   const [view, setView] = useState<CalendarViewMode>(initialView);
 
@@ -64,43 +68,40 @@ export function useDateNavigation(initialView: CalendarViewMode = 'week'): UseDa
   const { rangeStart, rangeEnd } = useMemo(() => {
     switch (view) {
       case 'day': {
-        const dateStr = toDateString(currentDate);
-        return {
-          rangeStart: new Date(`${dateStr}T00:00:00`).toISOString(),
-          rangeEnd: new Date(`${dateStr}T23:59:59.999`).toISOString(),
-        };
+        const dk = toDateString(currentDate);
+        const r = getDayRange(dk, tz);
+        return { rangeStart: r.startUTC, rangeEnd: r.endUTC };
       }
       case 'three-day': {
-        const tdStart = new Date(currentDate);
-        tdStart.setHours(0, 0, 0, 0);
-        const tdEnd = new Date(tdStart);
-        tdEnd.setDate(tdEnd.getDate() + 2);
-        tdEnd.setHours(23, 59, 59, 999);
+        const dkStart = toDateString(currentDate);
+        const dkEnd = addDays(dkStart, 2);
         return {
-          rangeStart: tdStart.toISOString(),
-          rangeEnd: tdEnd.toISOString(),
+          rangeStart: getDayRange(dkStart, tz).startUTC,
+          rangeEnd: getDayRange(dkEnd, tz).endUTC,
         };
       }
       case 'week': {
-        const ws = getWeekStart(currentDate);
-        const we = getWeekEnd(currentDate);
+        const dkStart = toDateString(getWeekStart(currentDate));
+        const dkEnd = toDateString(getWeekEnd(currentDate));
         return {
-          rangeStart: ws.toISOString(),
-          rangeEnd: we.toISOString(),
+          rangeStart: getDayRange(dkStart, tz).startUTC,
+          rangeEnd: getDayRange(dkEnd, tz).endUTC,
         };
       }
       case 'month':
       case 'agenda':
       default: {
-        const ms = getMonthStart(currentDate.getFullYear(), currentDate.getMonth());
-        const me = getMonthEnd(currentDate.getFullYear(), currentDate.getMonth());
+        const dkStart = toDateString(
+          getMonthStart(currentDate.getFullYear(), currentDate.getMonth())
+        );
+        const dkEnd = toDateString(getMonthEnd(currentDate.getFullYear(), currentDate.getMonth()));
         return {
-          rangeStart: ms.toISOString(),
-          rangeEnd: me.toISOString(),
+          rangeStart: getDayRange(dkStart, tz).startUTC,
+          rangeEnd: getDayRange(dkEnd, tz).endUTC,
         };
       }
     }
-  }, [currentDate, view]);
+  }, [currentDate, view, tz]);
 
   const title = useMemo(() => {
     const y = currentDate.getFullYear();

--- a/src/hooks/useTenantTimezone.ts
+++ b/src/hooks/useTenantTimezone.ts
@@ -1,0 +1,12 @@
+import { detectBrowserTimezone, resolveTimezone } from '@coongro/datetime';
+import { useSettings } from '@coongro/plugin-sdk';
+
+/**
+ * Devuelve la timezone IANA del tenant.
+ * Lee `core.timezone`. Si no existe, cae al del browser. Siempre válida.
+ */
+export function useTenantTimezone(): string {
+  const { values } = useSettings('core.');
+  const stored = values['core.timezone'] as string | undefined;
+  return resolveTimezone(stored ?? detectBrowserTimezone());
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export { useEventsByEntity } from './hooks/useEventsByEntity.js';
 export type { UseEventsByEntityResult } from './hooks/useEventsByEntity.js';
 export { useDateNavigation } from './hooks/useDateNavigation.js';
 export type { UseDateNavigationResult } from './hooks/useDateNavigation.js';
+export { useTenantTimezone } from './hooks/useTenantTimezone.js';
 
 // Components
 export { CalendarView } from './components/calendar/CalendarView.js';

--- a/src/repositories/calendar.repository.ts
+++ b/src/repositories/calendar.repository.ts
@@ -1,3 +1,4 @@
+import { dbNow } from '@coongro/datetime';
 import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
 import { eq, and, isNull } from 'drizzle-orm';
 
@@ -40,7 +41,7 @@ export class CalendarRepository {
     return this.db.ormQuery((tx) =>
       tx
         .update(calendarTable)
-        .set({ ...data, updated_at: new Date().toISOString() } as Partial<CalendarRow>)
+        .set({ ...data, updated_at: dbNow() } as Partial<CalendarRow>)
         .where(eq(calendarTable.id, id))
         .returning()
     );
@@ -51,7 +52,7 @@ export class CalendarRepository {
   }
 
   async softDelete({ id }: { id: string }): Promise<CalendarRow[]> {
-    const now = new Date().toISOString();
+    const now = dbNow();
     return this.db.ormQuery((tx) =>
       tx
         .update(calendarTable)
@@ -65,7 +66,7 @@ export class CalendarRepository {
     return this.db.ormQuery((tx) =>
       tx
         .update(calendarTable)
-        .set({ deleted_at: null, updated_at: new Date().toISOString() } as Partial<CalendarRow>)
+        .set({ deleted_at: null, updated_at: dbNow() } as Partial<CalendarRow>)
         .where(eq(calendarTable.id, id))
         .returning()
     );
@@ -79,7 +80,7 @@ export class CalendarRepository {
         .update(calendarTable)
         .set({
           is_visible: !existing.is_visible,
-          updated_at: new Date().toISOString(),
+          updated_at: dbNow(),
         } as Partial<CalendarRow>)
         .where(eq(calendarTable.id, id))
         .returning()

--- a/src/repositories/event-type.repository.ts
+++ b/src/repositories/event-type.repository.ts
@@ -1,3 +1,4 @@
+import { dbNow } from '@coongro/datetime';
 import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
 import { eq, and, or, ilike, isNull } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';
@@ -39,7 +40,7 @@ export class EventTypeRepository {
     return this.db.ormQuery((tx) =>
       tx
         .update(eventTypeTable)
-        .set({ ...data, updated_at: new Date().toISOString() } as Partial<EventTypeRow>)
+        .set({ ...data, updated_at: dbNow() } as Partial<EventTypeRow>)
         .where(eq(eventTypeTable.id, id))
         .returning()
     );
@@ -50,7 +51,7 @@ export class EventTypeRepository {
   }
 
   async softDelete({ id }: { id: string }): Promise<EventTypeRow[]> {
-    const now = new Date().toISOString();
+    const now = dbNow();
     return this.db.ormQuery((tx) =>
       tx
         .update(eventTypeTable)
@@ -64,7 +65,7 @@ export class EventTypeRepository {
     return this.db.ormQuery((tx) =>
       tx
         .update(eventTypeTable)
-        .set({ deleted_at: null, updated_at: new Date().toISOString() } as Partial<EventTypeRow>)
+        .set({ deleted_at: null, updated_at: dbNow() } as Partial<EventTypeRow>)
         .where(eq(eventTypeTable.id, id))
         .returning()
     );

--- a/src/repositories/event.repository.ts
+++ b/src/repositories/event.repository.ts
@@ -1,9 +1,29 @@
+import { dbNow, getDayRange, parseDateKey, toUTCTimestamp } from '@coongro/datetime';
 import type { ModuleDatabaseAPI } from '@coongro/plugin-sdk';
 import { eq, and, or, ilike, isNull, gte, lte, asc, desc, sql, inArray } from 'drizzle-orm';
 import type { SQL } from 'drizzle-orm';
 
 import { eventTable } from '../schema/event.js';
 import type { EventRow, NewEventRow } from '../schema/event.js';
+import type { CalendarEvent } from '../types/event.js';
+
+/** Convierte filtros que llegan como string ISO desde el API a `Date` para Drizzle. */
+function asDate(v: string | Date | undefined): Date | undefined {
+  return typeof v === 'string' ? new Date(v) : v;
+}
+
+/** Mapper boundary: row de DB (Date) → entidad de dominio (UTCTimestamp). */
+function toCalendarEvent(row: EventRow): CalendarEvent {
+  return {
+    ...row,
+    start_at: toUTCTimestamp(row.start_at),
+    end_at: toUTCTimestamp(row.end_at),
+    recurrence_end: row.recurrence_end ? toUTCTimestamp(row.recurrence_end) : null,
+    deleted_at: row.deleted_at ? toUTCTimestamp(row.deleted_at) : null,
+    created_at: toUTCTimestamp(row.created_at),
+    updated_at: toUTCTimestamp(row.updated_at),
+  };
+}
 
 export interface EventSearchParams {
   query?: string;
@@ -13,8 +33,8 @@ export interface EventSearchParams {
   eventTypeId?: string;
   entityId?: string;
   entityType?: string;
-  from?: string;
-  to?: string;
+  from?: string | Date;
+  to?: string | Date;
   tags?: string[];
   includeDeleted?: boolean;
   limit?: number;
@@ -31,21 +51,24 @@ export interface CountResult {
 export class EventRepository {
   constructor(private readonly db: ModuleDatabaseAPI) {}
 
-  async list(): Promise<EventRow[]> {
-    return this.db.ormQuery((tx) =>
+  async list(): Promise<CalendarEvent[]> {
+    const rows = await this.db.ormQuery((tx) =>
       tx.select().from(eventTable).where(isNull(eventTable.deleted_at))
     );
+    return rows.map(toCalendarEvent);
   }
 
-  async getById({ id }: { id: string }): Promise<EventRow | undefined> {
+  async getById({ id }: { id: string }): Promise<CalendarEvent | undefined> {
     const rows = await this.db.ormQuery((tx) =>
       tx.select().from(eventTable).where(eq(eventTable.id, id)).limit(1)
     );
-    return rows[0];
+    return rows[0] ? toCalendarEvent(rows[0]) : undefined;
   }
 
-  async create({ data }: { data: NewEventRow }): Promise<EventRow[]> {
-    // Validar solapamiento si tiene fecha inicio y fin
+  async create({ data }: { data: NewEventRow }): Promise<CalendarEvent[]> {
+    // Normalizar string ISO → Date para columnas mode:'date'
+    if (typeof data.start_at === 'string') data.start_at = new Date(data.start_at);
+    if (typeof data.end_at === 'string') data.end_at = new Date(data.end_at);
     if (data.start_at && data.end_at && !data.all_day) {
       const conflicts = await this.findConflicts({
         startAt: data.start_at,
@@ -66,45 +89,49 @@ export class EventRepository {
       all_day: data.all_day ?? false,
       is_active: data.is_active ?? true,
     };
-    return this.db.ormQuery((tx) => tx.insert(eventTable).values(row).returning());
+    const rows = await this.db.ormQuery((tx) => tx.insert(eventTable).values(row).returning());
+    return rows.map(toCalendarEvent);
   }
 
-  async update({ id, data }: { id: string; data: Partial<NewEventRow> }): Promise<EventRow[]> {
-    return this.db.ormQuery((tx) =>
+  async update({ id, data }: { id: string; data: Partial<NewEventRow> }): Promise<CalendarEvent[]> {
+    const rows = await this.db.ormQuery((tx) =>
       tx
         .update(eventTable)
-        .set({ ...data, updated_at: new Date().toISOString() } as Partial<EventRow>)
+        .set({ ...data, updated_at: dbNow() } as Partial<EventRow>)
         .where(eq(eventTable.id, id))
         .returning()
     );
+    return rows.map(toCalendarEvent);
   }
 
   async delete({ id }: { id: string }): Promise<void> {
     await this.db.ormQuery((tx) => tx.delete(eventTable).where(eq(eventTable.id, id)));
   }
 
-  async softDelete({ id }: { id: string }): Promise<EventRow[]> {
-    const now = new Date().toISOString();
-    return this.db.ormQuery((tx) =>
+  async softDelete({ id }: { id: string }): Promise<CalendarEvent[]> {
+    const now = dbNow();
+    const rows = await this.db.ormQuery((tx) =>
       tx
         .update(eventTable)
         .set({ deleted_at: now, updated_at: now } as Partial<EventRow>)
         .where(eq(eventTable.id, id))
         .returning()
     );
+    return rows.map(toCalendarEvent);
   }
 
-  async restore({ id }: { id: string }): Promise<EventRow[]> {
-    return this.db.ormQuery((tx) =>
+  async restore({ id }: { id: string }): Promise<CalendarEvent[]> {
+    const rows = await this.db.ormQuery((tx) =>
       tx
         .update(eventTable)
-        .set({ deleted_at: null, updated_at: new Date().toISOString() } as Partial<EventRow>)
+        .set({ deleted_at: null, updated_at: dbNow() } as Partial<EventRow>)
         .where(eq(eventTable.id, id))
         .returning()
     );
+    return rows.map(toCalendarEvent);
   }
 
-  async search(params: EventSearchParams): Promise<EventRow[]> {
+  async search(params: EventSearchParams): Promise<CalendarEvent[]> {
     const {
       query,
       status,
@@ -123,7 +150,7 @@ export class EventRepository {
       orderDir = 'asc',
     } = params;
 
-    return this.db.ormQuery((tx) => {
+    const rows = await this.db.ormQuery((tx) => {
       const conditions: SQL[] = [];
 
       if (!includeDeleted) {
@@ -149,8 +176,10 @@ export class EventRepository {
       if (eventTypeId) conditions.push(eq(eventTable.event_type_id, eventTypeId));
       if (entityId) conditions.push(eq(eventTable.entity_id, entityId));
       if (entityType) conditions.push(eq(eventTable.entity_type, entityType));
-      if (from) conditions.push(gte(eventTable.start_at, from));
-      if (to) conditions.push(lte(eventTable.start_at, to));
+      const fromDate = asDate(from);
+      const toDate = asDate(to);
+      if (fromDate) conditions.push(gte(eventTable.start_at, fromDate));
+      if (toDate) conditions.push(lte(eventTable.start_at, toDate));
 
       const sortCol =
         orderBy === 'title'
@@ -173,28 +202,37 @@ export class EventRepository {
 
       return q;
     });
+    return rows.map(toCalendarEvent);
   }
 
-  async listByDateRange({ from, to }: { from: string; to: string }): Promise<EventRow[]> {
-    return this.db.ormQuery((tx) =>
+  async listByDateRange({
+    from,
+    to,
+  }: {
+    from: string | Date;
+    to: string | Date;
+  }): Promise<CalendarEvent[]> {
+    const fromDate = asDate(from);
+    const toDate = asDate(to);
+    const rows = await this.db.ormQuery((tx) =>
       tx
         .select()
         .from(eventTable)
         .where(
           and(
             isNull(eventTable.deleted_at),
-            gte(eventTable.start_at, from),
-            lte(eventTable.start_at, to)
+            gte(eventTable.start_at, fromDate),
+            lte(eventTable.start_at, toDate)
           )
         )
         .orderBy(asc(eventTable.start_at))
     );
+    return rows.map(toCalendarEvent);
   }
 
-  async listByDate({ date }: { date: string }): Promise<EventRow[]> {
-    const dayStart = `${date}T00:00:00.000Z`;
-    const dayEnd = `${date}T23:59:59.999Z`;
-    return this.listByDateRange({ from: dayStart, to: dayEnd });
+  async listByDate({ date, tz }: { date: string; tz: string }): Promise<CalendarEvent[]> {
+    const { startUTC, endUTC } = getDayRange(parseDateKey(date), tz);
+    return this.listByDateRange({ from: startUTC, to: endUTC });
   }
 
   async listByEntity({
@@ -203,8 +241,8 @@ export class EventRepository {
   }: {
     entityId: string;
     entityType: string;
-  }): Promise<EventRow[]> {
-    return this.db.ormQuery((tx) =>
+  }): Promise<CalendarEvent[]> {
+    const rows = await this.db.ormQuery((tx) =>
       tx
         .select()
         .from(eventTable)
@@ -217,6 +255,7 @@ export class EventRepository {
         )
         .orderBy(asc(eventTable.start_at))
     );
+    return rows.map(toCalendarEvent);
   }
 
   async listByCalendar({
@@ -227,14 +266,16 @@ export class EventRepository {
     calendarId: string;
     from?: string;
     to?: string;
-  }): Promise<EventRow[]> {
-    return this.db.ormQuery((tx) => {
+  }): Promise<CalendarEvent[]> {
+    const rows = await this.db.ormQuery((tx) => {
       const conditions: SQL[] = [
         isNull(eventTable.deleted_at),
         eq(eventTable.calendar_id, calendarId),
       ];
-      if (from) conditions.push(gte(eventTable.start_at, from));
-      if (to) conditions.push(lte(eventTable.start_at, to));
+      const fromDate = asDate(from);
+      const toDate = asDate(to);
+      if (fromDate) conditions.push(gte(eventTable.start_at, fromDate));
+      if (toDate) conditions.push(lte(eventTable.start_at, toDate));
 
       return tx
         .select()
@@ -242,6 +283,7 @@ export class EventRepository {
         .where(and(...conditions))
         .orderBy(asc(eventTable.start_at));
     });
+    return rows.map(toCalendarEvent);
   }
 
   async listUpcoming({
@@ -250,9 +292,9 @@ export class EventRepository {
   }: {
     limit?: number;
     calendarIds?: string[];
-  }): Promise<EventRow[]> {
-    const now = new Date().toISOString();
-    return this.db.ormQuery((tx) => {
+  }): Promise<CalendarEvent[]> {
+    const now = dbNow();
+    const rows = await this.db.ormQuery((tx) => {
       const conditions: SQL[] = [isNull(eventTable.deleted_at), gte(eventTable.start_at, now)];
       if (calendarIds && calendarIds.length > 0) {
         conditions.push(inArray(eventTable.calendar_id, calendarIds));
@@ -265,6 +307,7 @@ export class EventRepository {
         .orderBy(asc(eventTable.start_at))
         .limit(limit);
     });
+    return rows.map(toCalendarEvent);
   }
 
   async findConflicts({
@@ -272,16 +315,17 @@ export class EventRepository {
     endAt,
     excludeId,
   }: {
-    startAt: string;
-    endAt: string;
+    startAt: string | Date;
+    endAt: string | Date;
     excludeId?: string;
-  }): Promise<EventRow[]> {
-    return this.db.ormQuery((tx) => {
+  }): Promise<CalendarEvent[]> {
+    const startDate = asDate(startAt);
+    const endDate = asDate(endAt);
+    const rows = await this.db.ormQuery((tx) => {
       const conditions: SQL[] = [
         isNull(eventTable.deleted_at),
-        // Solapamiento: evento existente empieza antes de que termine el nuevo Y termina después de que empiece
-        lte(eventTable.start_at, endAt),
-        gte(eventTable.end_at, startAt),
+        lte(eventTable.start_at, endDate),
+        gte(eventTable.end_at, startDate),
       ];
 
       if (excludeId) {
@@ -294,6 +338,7 @@ export class EventRepository {
         .where(and(...conditions))
         .orderBy(asc(eventTable.start_at));
     });
+    return rows.map(toCalendarEvent);
   }
 
   async moveEvent({
@@ -302,27 +347,30 @@ export class EventRepository {
     endAt,
   }: {
     id: string;
-    startAt: string;
-    endAt: string;
-  }): Promise<EventRow[]> {
-    return this.db.ormQuery((tx) =>
+    startAt: string | Date;
+    endAt: string | Date;
+  }): Promise<CalendarEvent[]> {
+    const rows = await this.db.ormQuery((tx) =>
       tx
         .update(eventTable)
         .set({
-          start_at: startAt,
-          end_at: endAt,
-          updated_at: new Date().toISOString(),
+          start_at: asDate(startAt),
+          end_at: asDate(endAt),
+          updated_at: dbNow(),
         } as Partial<EventRow>)
         .where(eq(eventTable.id, id))
         .returning()
     );
+    return rows.map(toCalendarEvent);
   }
 
   async countByStatus({ from, to }: { from?: string; to?: string } = {}): Promise<CountResult[]> {
     return this.db.ormQuery((tx) => {
       const conditions: SQL[] = [isNull(eventTable.deleted_at)];
-      if (from) conditions.push(gte(eventTable.start_at, from));
-      if (to) conditions.push(lte(eventTable.start_at, to));
+      const fromDate = asDate(from);
+      const toDate = asDate(to);
+      if (fromDate) conditions.push(gte(eventTable.start_at, fromDate));
+      if (toDate) conditions.push(lte(eventTable.start_at, toDate));
 
       return tx
         .select({
@@ -335,7 +383,15 @@ export class EventRepository {
     });
   }
 
-  async countByDate({ from, to }: { from: string; to: string }): Promise<CountResult[]> {
+  async countByDate({
+    from,
+    to,
+  }: {
+    from: string | Date;
+    to: string | Date;
+  }): Promise<CountResult[]> {
+    const fromDate = asDate(from);
+    const toDate = asDate(to);
     return this.db.ormQuery((tx) =>
       tx
         .select({
@@ -346,8 +402,8 @@ export class EventRepository {
         .where(
           and(
             isNull(eventTable.deleted_at),
-            gte(eventTable.start_at, from),
-            lte(eventTable.start_at, to)
+            gte(eventTable.start_at, fromDate),
+            lte(eventTable.start_at, toDate)
           )
         )
         .groupBy(sql`${eventTable.start_at}::date`)
@@ -357,8 +413,10 @@ export class EventRepository {
   async countByCalendar({ from, to }: { from?: string; to?: string } = {}): Promise<CountResult[]> {
     return this.db.ormQuery((tx) => {
       const conditions: SQL[] = [isNull(eventTable.deleted_at)];
-      if (from) conditions.push(gte(eventTable.start_at, from));
-      if (to) conditions.push(lte(eventTable.start_at, to));
+      const fromDate = asDate(from);
+      const toDate = asDate(to);
+      if (fromDate) conditions.push(gte(eventTable.start_at, fromDate));
+      if (toDate) conditions.push(lte(eventTable.start_at, toDate));
 
       return tx
         .select({

--- a/src/schema/calendar.ts
+++ b/src/schema/calendar.ts
@@ -9,11 +9,11 @@ export const calendarTable = pgTable('module_calendar_calendars', {
   is_visible: boolean('is_visible').notNull(),
   is_default: boolean('is_default').notNull(),
   metadata: jsonb('metadata'),
-  deleted_at: timestamp('deleted_at', { mode: 'string' }),
-  created_at: timestamp('created_at', { mode: 'string' })
+  deleted_at: timestamp('deleted_at', { mode: 'date', withTimezone: true }),
+  created_at: timestamp('created_at', { mode: 'date', withTimezone: true })
     .notNull()
     .default(sql`now()`),
-  updated_at: timestamp('updated_at', { mode: 'string' })
+  updated_at: timestamp('updated_at', { mode: 'date', withTimezone: true })
     .notNull()
     .default(sql`now()`),
 });

--- a/src/schema/event-type.ts
+++ b/src/schema/event-type.ts
@@ -8,11 +8,11 @@ export const eventTypeTable = pgTable('module_calendar_event_types', {
   default_duration: integer('default_duration').notNull(),
   description: text('description'),
   metadata: jsonb('metadata'),
-  deleted_at: timestamp('deleted_at', { mode: 'string' }),
-  created_at: timestamp('created_at', { mode: 'string' })
+  deleted_at: timestamp('deleted_at', { mode: 'date', withTimezone: true }),
+  created_at: timestamp('created_at', { mode: 'date', withTimezone: true })
     .notNull()
     .default(sql`now()`),
-  updated_at: timestamp('updated_at', { mode: 'string' })
+  updated_at: timestamp('updated_at', { mode: 'date', withTimezone: true })
     .notNull()
     .default(sql`now()`),
 });

--- a/src/schema/event.ts
+++ b/src/schema/event.ts
@@ -5,8 +5,8 @@ export const eventTable = pgTable('module_calendar_events', {
   id: uuid('id').primaryKey().notNull(),
   title: text('title').notNull(),
   description: text('description'),
-  start_at: timestamp('start_at', { mode: 'string' }).notNull(),
-  end_at: timestamp('end_at', { mode: 'string' }).notNull(),
+  start_at: timestamp('start_at', { mode: 'date', withTimezone: true }).notNull(),
+  end_at: timestamp('end_at', { mode: 'date', withTimezone: true }).notNull(),
   all_day: boolean('all_day').notNull(),
   status: text('status').notNull(),
   color: text('color'),
@@ -16,18 +16,18 @@ export const eventTable = pgTable('module_calendar_events', {
   entity_id: text('entity_id'),
   entity_type: text('entity_type'),
   recurrence_rule: text('recurrence_rule'),
-  recurrence_end: timestamp('recurrence_end', { mode: 'string' }),
+  recurrence_end: timestamp('recurrence_end', { mode: 'date', withTimezone: true }),
   recurrence_parent_id: text('recurrence_parent_id'),
   tags: jsonb('tags'),
   metadata: jsonb('metadata'),
   reminders: jsonb('reminders'),
   notes: text('notes'),
   is_active: boolean('is_active').notNull(),
-  deleted_at: timestamp('deleted_at', { mode: 'string' }),
-  created_at: timestamp('created_at', { mode: 'string' })
+  deleted_at: timestamp('deleted_at', { mode: 'date', withTimezone: true }),
+  created_at: timestamp('created_at', { mode: 'date', withTimezone: true })
     .notNull()
     .default(sql`now()`),
-  updated_at: timestamp('updated_at', { mode: 'string' })
+  updated_at: timestamp('updated_at', { mode: 'date', withTimezone: true })
     .notNull()
     .default(sql`now()`),
 });

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,3 +1,5 @@
+import type { UTCTimestamp } from '@coongro/datetime';
+
 export type EventStatus =
   | 'scheduled'
   | 'confirmed'
@@ -10,8 +12,8 @@ export interface CalendarEvent {
   id: string;
   title: string;
   description: string | null;
-  start_at: string;
-  end_at: string;
+  start_at: UTCTimestamp;
+  end_at: UTCTimestamp;
   all_day: boolean;
   status: string;
   color: string | null;
@@ -21,24 +23,24 @@ export interface CalendarEvent {
   entity_id: string | null;
   entity_type: string | null;
   recurrence_rule: string | null;
-  recurrence_end: string | null;
+  recurrence_end: UTCTimestamp | null;
   recurrence_parent_id: string | null;
   tags: unknown;
   metadata: unknown;
   reminders: unknown;
   notes: string | null;
   is_active: boolean;
-  deleted_at: string | null;
-  created_at: string;
-  updated_at: string;
+  deleted_at: UTCTimestamp | null;
+  created_at: UTCTimestamp;
+  updated_at: UTCTimestamp;
 }
 
 export interface EventCreateData {
   id?: string;
   title: string;
   description?: string;
-  start_at: string;
-  end_at: string;
+  start_at: UTCTimestamp;
+  end_at: UTCTimestamp;
   all_day?: boolean;
   status?: EventStatus;
   color?: string;
@@ -48,7 +50,7 @@ export interface EventCreateData {
   entity_id?: string;
   entity_type?: string;
   recurrence_rule?: string;
-  recurrence_end?: string;
+  recurrence_end?: UTCTimestamp;
   recurrence_parent_id?: string;
   tags?: unknown;
   metadata?: unknown;

--- a/src/types/filters.ts
+++ b/src/types/filters.ts
@@ -8,8 +8,8 @@ export interface EventFilters {
   eventTypeId?: string;
   entityId?: string;
   entityType?: string;
-  from?: string;
-  to?: string;
+  from?: string | Date;
+  to?: string | Date;
   tags?: string[];
   includeDeleted?: boolean;
   limit?: number;

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,6 +1,21 @@
 /**
- * Helpers de fecha/hora para el calendario
+ * Helpers de fecha/hora para el calendario.
+ * Wrappers sobre `@coongro/datetime` que aceptan tanto branded como string crudo
+ * (cast confiado en este boundary). `tz` siempre requerido.
  */
+
+import {
+  addMinutes as addMinutesCore,
+  asUTCTimestamp,
+  diffMinutes as diffMinutesCore,
+  formatLocalDate,
+  formatLocalDateTime,
+  formatLocalTime,
+  isSameDay as isSameDayCore,
+  toDateKey,
+  type DateKey,
+  type UTCTimestamp,
+} from '@coongro/datetime';
 
 const DAYS = ['Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado'];
 const MONTHS = [
@@ -19,18 +34,23 @@ const MONTHS = [
 ];
 const SHORT_DAYS = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
 
-export function formatEventDate(isoString: string): string {
-  const d = new Date(isoString);
-  return `${d.getDate()} ${MONTHS[d.getMonth()]} ${d.getFullYear()}`;
+type DateLike = string | Date | UTCTimestamp;
+
+function asTs(value: DateLike): UTCTimestamp | Date {
+  if (typeof value === 'string') return asUTCTimestamp(value);
+  return value;
 }
 
-export function formatEventTime(isoString: string): string {
-  const d = new Date(isoString);
-  return d.toLocaleTimeString('es', { hour: '2-digit', minute: '2-digit', hour12: false });
+export function formatEventDate(value: DateLike, tz: string): string {
+  return formatLocalDate(asTs(value), tz);
 }
 
-export function formatEventDateTime(isoString: string): string {
-  return `${formatEventDate(isoString)} ${formatEventTime(isoString)}`;
+export function formatEventTime(value: DateLike, tz: string): string {
+  return formatLocalTime(asTs(value), tz);
+}
+
+export function formatEventDateTime(value: DateLike, tz: string): string {
+  return formatLocalDateTime(asTs(value), tz);
 }
 
 export function getDayName(date: Date): string {
@@ -45,7 +65,6 @@ export function getMonthName(month: number): string {
   return MONTHS[month];
 }
 
-/** Retorna el primer día de la semana (lunes) para una fecha dada */
 export function getWeekStart(date: Date): Date {
   const d = new Date(date);
   const day = d.getDay();
@@ -55,7 +74,6 @@ export function getWeekStart(date: Date): Date {
   return d;
 }
 
-/** Retorna el último día de la semana (domingo) para una fecha dada */
 export function getWeekEnd(date: Date): Date {
   const start = getWeekStart(date);
   const end = new Date(start);
@@ -64,7 +82,6 @@ export function getWeekEnd(date: Date): Date {
   return end;
 }
 
-/** Retorna array de fechas para una semana */
 export function getWeekDays(date: Date): Date[] {
   const start = getWeekStart(date);
   return Array.from({ length: 7 }, (_, i) => {
@@ -74,31 +91,23 @@ export function getWeekDays(date: Date): Date[] {
   });
 }
 
-/** Retorna el primer día del mes */
 export function getMonthStart(year: number, month: number): Date {
   return new Date(year, month, 1);
 }
 
-/** Retorna el último día del mes */
 export function getMonthEnd(year: number, month: number): Date {
   return new Date(year, month + 1, 0, 23, 59, 59, 999);
 }
 
-/** Retorna los días del mes incluyendo padding de semanas adyacentes */
 export function getMonthGridDays(year: number, month: number): Date[] {
   const firstDay = getMonthStart(year, month);
   const lastDay = getMonthEnd(year, month);
-
-  // Retroceder al lunes de la primera semana
   const start = getWeekStart(firstDay);
-
-  // Avanzar al domingo de la última semana
   const endDay = lastDay.getDay();
   const end = new Date(lastDay);
   if (endDay !== 0) {
     end.setDate(end.getDate() + (7 - endDay));
   }
-
   const days: Date[] = [];
   const current = new Date(start);
   while (current <= end) {
@@ -108,7 +117,6 @@ export function getMonthGridDays(year: number, month: number): Date[] {
   return days;
 }
 
-/** Genera slots horarios para un día */
 export function generateTimeSlots(startHour: number, endHour: number, step: number): string[] {
   const slots: string[] = [];
   for (let h = startHour; h < endHour; h++) {
@@ -119,31 +127,25 @@ export function generateTimeSlots(startHour: number, endHour: number, step: numb
   return slots;
 }
 
-/** Formato ISO date-only (YYYY-MM-DD) */
-export function toDateString(date: Date): string {
+/** Formato `YYYY-MM-DD` brandeado como `DateKey`. */
+export function toDateString(date: Date): DateKey {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, '0');
   const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
+  return `${y}-${m}-${d}` as DateKey;
 }
 
-/** Compara dos fechas ignorando hora */
-export function isSameDay(a: Date, b: Date): boolean {
-  return (
-    a.getFullYear() === b.getFullYear() &&
-    a.getMonth() === b.getMonth() &&
-    a.getDate() === b.getDate()
-  );
+/** Compara día en el timezone del tenant. */
+export function isSameDay(a: DateLike, b: DateLike, tz: string): boolean {
+  return isSameDayCore(asTs(a), asTs(b), tz);
 }
 
-/** Diferencia en minutos entre dos ISO strings */
-export function diffMinutes(start: string, end: string): number {
-  return Math.round((new Date(end).getTime() - new Date(start).getTime()) / 60000);
+export function diffMinutes(start: DateLike, end: DateLike): number {
+  return diffMinutesCore(asTs(start), asTs(end));
 }
 
-/** Sumar minutos a un ISO string */
-export function addMinutes(isoString: string, minutes: number): string {
-  const d = new Date(isoString);
-  d.setMinutes(d.getMinutes() + minutes);
-  return d.toISOString();
+export function addMinutes(value: DateLike, minutes: number): UTCTimestamp {
+  return addMinutesCore(asTs(value), minutes);
 }
+
+export { toDateKey };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,9 @@
       ],
       "@coongro/plugin-sdk/*": [
         "../../packages/plugin-sdk/dist/*"
+      ],
+      "@coongro/datetime": [
+        "../../packages/datetime/dist/index.d.ts"
       ]
     }
   },


### PR DESCRIPTION
Work item: COONG-94

## Changes

- **Entities** — `CalendarEvent` usa `UTCTimestamp` branded en timestamps.
- **Schemas** — columnas `timestamp with time zone` + `mode: 'date'` (migration `0001_lean_white_tiger`). Repositories mapean rows con `toUTCTimestamp()`.
- **utils/date.ts** — wrappers requieren `tz` (no más fallback al browser TZ). Componentes consumen `useTenantTimezone()`.
- **DateKey string equality** para comparaciones día/hoy (evita drift browser-TZ vs tenant-TZ).
- **useDateNavigation** retorna `Date` ranges (consumo directo en filtros Drizzle).
- **Nuevo** `useTenantTimezone()` hook lee `workspace.timezone`.

Fixes el bug del turno 22:30 ART que se renderizaba como 01:30 del día siguiente.

## Testing

- [x] `npm run build` passes
- [x] typecheck + format + lint limpio
- [x] E2E: evento 22:30 ART se muestra a las 22:30 en Agenda/Week/Day

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Events and calendar dates now display in your configured timezone instead of browser timezone
  * Added tenant timezone settings support for consistent date/time representation across calendar views

* **Bug Fixes**
  * Fixed event rendering times when created at specific times in certain timezones (e.g., events at 22:30 ART now display correctly)

* **Chores**
  * Updated database schema to use timezone-aware timestamp storage
  * Added timezone-aware datetime library dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->