### PR TITLE
ci: guard husky en workflows de release/publish (COONG-244)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,13 @@ jobs:
     name: Build & Publish to Production
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Los git commit/push que hacen changesets/action y el sync/tag NO deben
+    # disparar los hooks de husky: pre-commit/pre-push corren `npm run quality`,
+    # cuyo format:check falla en CI por el prettier flotante (npm install baja
+    # una minor nueva). Sin esto, el publish ocurre pero el git push del sync/tag
+    # falla → develop queda atrás (divergencia) o el tag/release se pierde.
+    env:
+      HUSKY: 0
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ jobs:
     name: Version or Publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Los git commit/push que hacen changesets/action y el sync/tag NO deben
+    # disparar los hooks de husky: pre-commit/pre-push corren `npm run quality`,
+    # cuyo format:check falla en CI por el prettier flotante (npm install baja
+    # una minor nueva). Sin esto, el publish ocurre pero el git push del sync/tag
+    # falla → develop queda atrás (divergencia) o el tag/release se pierde.
+    env:
+      HUSKY: 0
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Agrega `env: HUSKY: 0` a nivel job en release.yml y publish.yml.

Sin esto, los `git commit/push` que hacen changesets/action (bump), el sync develop←staging y el tag de publish disparan el pre-commit/pre-push de husky (`npm run quality`), que falla en CI por el prettier flotante → el publish ocurre pero el sync/tag se pierde (divergencia develop/staging).

Mismo fix ya validado end-to-end en contacts (1.3.0 → prod).

COONG-244