### PR TITLE
ci: template robusto de release.yml (COONG-244)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,16 +4,20 @@ on:
   push:
     branches: [staging]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Version or Publish
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Los git commit/push que hacen changesets/action y el sync/tag NO deben
-    # disparar los hooks de husky: pre-commit/pre-push corren `npm run quality`,
-    # cuyo format:check falla en CI por el prettier flotante (npm install baja
-    # una minor nueva). Sin esto, el publish ocurre pero el git push del sync/tag
-    # falla → develop queda atrás (divergencia) o el tag/release se pierde.
+    # Los git commit/push que hacen changesets/action (bump) y el paso de sync
+    # NO deben disparar los hooks de husky: el pre-commit/pre-push corre
+    # `npm run quality`, cuyo format:check falla en CI por el prettier flotante
+    # (npm install baja una minor nueva). Sin esto, el publish ocurre pero el
+    # `git push origin develop` del sync falla → develop queda atrás (divergencia).
     env:
       HUSKY: 0
     permissions:
@@ -58,21 +62,16 @@ jobs:
           echo "### Published $NAME@$VERSION to staging" >> $GITHUB_STEP_SUMMARY
 
       - name: Sync develop with staging
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.hasChangesets == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin develop
           git checkout develop
-          git merge staging --no-edit || {
+          if git merge origin/staging --no-edit; then
+            git push origin develop
+            echo "### ✅ develop synced with staging" >> $GITHUB_STEP_SUMMARY
+          else
             git merge --abort
-            gh pr create \
-              --base develop \
-              --head staging \
-              --title "sync: merge staging into develop (conflicts)" \
-              --body "Merge automático de staging a develop falló por conflictos. Resolver manualmente."
-            echo "::warning::Conflictos al sincronizar develop. PR creado."
-            exit 0
-          }
-          git push origin develop
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            echo "### ⚠️ Conflicts syncing develop ← staging. Manual sync required." >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
El template viejo condicionaba el Sync develop←staging a `published == 'true'`, que no se setea con el publish custom → develop divergía. Se unifica al template de contacts (`hasChangesets == 'false'`). Ver Problema 5. COONG-244